### PR TITLE
Disable site generation for lexer and model

### DIFF
--- a/lexer/pom.xml
+++ b/lexer/pom.xml
@@ -164,6 +164,15 @@ POSSIBILITY OF SUCH DAMAGE.
              </execution>
            </executions>
          </plugin>
+      
+      <!-- Disable Site for now -->
+      <plugin>
+        <artifactId>maven-site-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+          <skipDeploy>true</skipDeploy>
+        </configuration>
+      </plugin>
 			      
       
     </plugins>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -79,7 +79,14 @@
 	</executions>
 
       </plugin>
-    
+      <!-- Disable Site for now -->
+      <plugin>
+        <artifactId>maven-site-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+          <skipDeploy>true</skipDeploy>
+        </configuration>
+      </plugin>
          </plugins>    
   </build>
   


### PR DESCRIPTION
Disable site generation in pom so the maven `site` and `site:stage` phases can still be executed and complete successfully, even though a site does not exist.

Resolves #89

## Testing
```
$ mvn clean package site site:stage
..
..
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] gov.nasa.pds:registry-api-model 0.5.0-SNAPSHOT ..... SUCCESS [  7.932 s]
[INFO] PDS API Search Query Lexer 1.1.0-SNAPSHOT .......... SUCCESS [  2.951 s]
[INFO] gov.nasa.pds.api.registry-service 0.5.0-SNAPSHOT ... SUCCESS [03:06 min]
[INFO] gov.nasa.pds:registry 0.5.0-SNAPSHOT ............... SUCCESS [ 11.820 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:30 min
[INFO] Finished at: 2022-02-09T10:31:17-05:00
[INFO] ------------------------------------------------------------------------
```