### PR TITLE
Pds api 153: error messaging

### DIFF
--- a/model/swagger.yml
+++ b/model/swagger.yml
@@ -32,12 +32,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
-        '408':
-          description: request time out
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
       parameters:
         - name: start
           in: query
@@ -97,10 +99,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Singular"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -117,10 +123,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Singular"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -137,10 +147,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -171,10 +185,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -228,10 +246,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -286,13 +308,13 @@ paths:
         '200':
           $ref: "#/components/responses/Plural"
         '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/errorMessage'
-        '408':
-          description: request time out
+          $ref: "#/components/responses/Error"
+        '404':
+          $ref: "#/components/responses/Error"
+        '500':
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
       parameters:
         - name: start
           in: query
@@ -353,10 +375,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Singular"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -373,10 +399,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Singular"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -393,10 +423,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -427,10 +461,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -484,10 +522,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -541,10 +583,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -598,10 +644,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -656,13 +706,13 @@ paths:
         '200':
           $ref: "#/components/responses/Plural"
         '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/errorMessage'
-        '408':
-          description: request time out
+          $ref: "#/components/responses/Error"
+        '404':
+          $ref: "#/components/responses/Error"
+        '500':
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
       parameters:
         - name: start
           in: query
@@ -723,10 +773,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Singular"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -743,10 +797,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Singular"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -763,10 +821,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -797,10 +859,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -854,10 +920,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -911,10 +981,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -968,10 +1042,14 @@ paths:
       responses:
         '200':
           $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
         '404':
-          description: lidvid not found
+          $ref: "#/components/responses/Error"
         '500':
-          description: Internal server error
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
     parameters:
       - name: identifier
         in: path
@@ -1022,6 +1100,42 @@ externalDocs:
   url: 'https://github.com/NASA-PDS/pds-api-core'
 components:
   responses:
+    Error:
+      description: Unsuccessful request
+      content:
+        "*":
+          schema:
+            type: object
+        "*/*":
+          schema:
+            $ref: '#/components/schemas/errorMessage'
+        application/csv:
+          schema:
+            $ref: '#/components/schemas/errorMessage'
+        application/json:
+          schema:
+            $ref: '#/components/schemas/errorMessage'
+        application/kvp+json:
+          schema:
+            $ref: '#/components/schemas/errorMessage'
+        application/pds4+json:
+          schema:
+            $ref: '#/components/schemas/errorMessage'
+        application/pds4+xml:
+          schema:
+            $ref: '#/components/schemas/errorMessage'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/errorMessage'
+        text/csv:
+          schema:
+            $ref: '#/components/schemas/errorMessage'
+        text/html:
+          schema:
+            $ref: '#/components/schemas/errorMessage'
+        text/xml:
+          schema:
+            $ref: '#/components/schemas/errorMessage'
     Plural:
       description: Successful request
       content:
@@ -1331,22 +1445,10 @@ components:
     errorMessage:
       type: object
       required:
-        - url
-        - resource
-        - query
+        - request
         - message
       properties:
-        url:
-          type: string
-          xml:
-            prefix: 'pds_api'
-            namespace: 'http://pds.nasa.gov/api'
-        resource:
-          type: string
-          xml:
-            prefix: 'pds_api'
-            namespace: 'http://pds.nasa.gov/api'
-        query:
+        request:
           type: string
           xml:
             prefix: 'pds_api'
@@ -1361,9 +1463,7 @@ components:
         namespace: 'http://pds.nasa.gov/api'
       example:
         {
-          url: 'https://pds.nasa.gov/api/1.0/collections',
-          resource: '/collections',
-          query: 'q=mission qt 12',
+          request: 'https://pds.nasa.gov/api/1.0/collections?q=mission qt 12',
           message: 'query operator gt not supported on field mission'
         }
     pds4Product:

--- a/service/src/main/java/gov/nasa/pds/api/engineering/configuration/WebMVCConfig.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/configuration/WebMVCConfig.java
@@ -14,8 +14,11 @@ import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import gov.nasa.pds.api.engineering.serializer.CsvErrorMessageSerializer;
 import gov.nasa.pds.api.engineering.serializer.CsvPluralSerializer;
 import gov.nasa.pds.api.engineering.serializer.CsvSingularSerializer;
+import gov.nasa.pds.api.engineering.serializer.HtmlErrorMessageSerializer;
+import gov.nasa.pds.api.engineering.serializer.JsonErrorMessageSerializer;
 import gov.nasa.pds.api.engineering.serializer.JsonPluralSerializer;
 import gov.nasa.pds.api.engineering.serializer.JsonProductSerializer;
 import gov.nasa.pds.api.engineering.serializer.JsonSingularSerializer;
@@ -27,6 +30,7 @@ import gov.nasa.pds.api.engineering.serializer.PdsProductTextHtmlSerializer;
 import gov.nasa.pds.api.engineering.serializer.PdsProductXMLSerializer;
 import gov.nasa.pds.api.engineering.serializer.PdsProductsTextHtmlSerializer;
 import gov.nasa.pds.api.engineering.serializer.PdsProductsXMLSerializer;
+import gov.nasa.pds.api.engineering.serializer.XmlErrorMessageSerializer;
 
 @Configuration
 @EnableWebMvc
@@ -65,8 +69,11 @@ public class WebMVCConfig implements WebMvcConfigurer
 	public void configureMessageConverters(List<HttpMessageConverter<?>> converters)
 	{
 		WebMVCConfig.log.info("Number of converters available " + Integer.toString(converters.size()));
+		converters.add(new CsvErrorMessageSerializer());
 		converters.add(new CsvPluralSerializer());
 		converters.add(new CsvSingularSerializer());
+		converters.add(new HtmlErrorMessageSerializer());
+		converters.add(new JsonErrorMessageSerializer());
 		converters.add(new JsonPluralSerializer());
 		converters.add(new JsonSingularSerializer());
 		converters.add(new JsonProductSerializer());
@@ -78,5 +85,6 @@ public class WebMVCConfig implements WebMvcConfigurer
 		converters.add(new PdsProductXMLSerializer());
 		converters.add(new PdsProductsTextHtmlSerializer());
 		converters.add(new PdsProductsXMLSerializer());
+		converters.add(new XmlErrorMessageSerializer());
 	}
 }

--- a/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
@@ -4,6 +4,7 @@ package gov.nasa.pds.api.engineering.controllers;
 import gov.nasa.pds.api.base.BundlesApi;
 import gov.nasa.pds.api.engineering.elasticsearch.ElasticSearchHitIterator;
 import gov.nasa.pds.api.engineering.elasticsearch.ElasticSearchRegistrySearchRequestBuilder;
+import gov.nasa.pds.api.engineering.elasticsearch.business.ErrorFactory;
 import gov.nasa.pds.api.engineering.elasticsearch.business.LidVidNotFoundException;
 import gov.nasa.pds.api.engineering.elasticsearch.business.ProductVersionSelector;
 import gov.nasa.pds.api.engineering.elasticsearch.business.RequestAndResponseContext;
@@ -165,22 +166,22 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
          catch (ApplicationTypeException e)
          {
         	 log.error("Application type not implemented", e);
-        	 return new ResponseEntity<Object>(HttpStatus.NOT_IMPLEMENTED);
+        	 return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
          }
          catch (IOException e)
          {
         	 log.error("Couldn't serialize response for content type " + accept, e);
-        	 return new ResponseEntity<Object>(HttpStatus.INTERNAL_SERVER_ERROR);
+        	 return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.INTERNAL_SERVER_ERROR);
          }
          catch (LidVidNotFoundException e)
          {
         	 log.warn("Could not find lid(vid) in database: " + lidvid);
-        	 return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+        	 return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
          }
          catch (NothingFoundException e)
          {
         	 log.warn("Could not find any matching reference(s) in database.");
-        	 return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+        	 return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
          }
     }
 
@@ -201,22 +202,22 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
          catch (ApplicationTypeException e)
          {
         	 log.error("Application type not implemented", e);
-        	 return new ResponseEntity<Object>(HttpStatus.NOT_IMPLEMENTED);
+        	 return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
          }
          catch (IOException e)
          {
         	 log.error("Couldn't serialize response for content type " + accept, e);
-        	 return new ResponseEntity<Object>(HttpStatus.INTERNAL_SERVER_ERROR);
+        	 return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.INTERNAL_SERVER_ERROR);
          }
          catch (LidVidNotFoundException e)
          {
         	 log.warn("Could not find lid(vid) in database: " + lidvid);
-        	 return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+        	 return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
          }
          catch (NothingFoundException e)
          {
         	 log.warn("Could not find any matching reference(s) in database.");
-        	 return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+        	 return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
          }
     }
 

--- a/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyCollectionsApiController.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyCollectionsApiController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import javax.validation.Valid;
 import javax.servlet.http.HttpServletRequest;
 
+import gov.nasa.pds.api.engineering.elasticsearch.business.ErrorFactory;
 import gov.nasa.pds.api.engineering.elasticsearch.business.LidVidNotFoundException;
 import gov.nasa.pds.api.engineering.elasticsearch.business.RequestAndResponseContext;
 import gov.nasa.pds.api.engineering.exceptions.ApplicationTypeException;
@@ -134,23 +135,23 @@ public class MyCollectionsApiController extends MyProductsApiBareController impl
         catch (ApplicationTypeException e)
         {
         	log.error("Application type not implemented", e);
-       	 	return new ResponseEntity<Object>(HttpStatus.NOT_IMPLEMENTED);
+       	 	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
         }
         catch (LidVidNotFoundException e)
         {
             log.error("Couldn't find the lidvid " + e.getMessage());
-            return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+            return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
 
         }
         catch (IOException e)
         {
             log.error("Couldn't serialize response for content type " + accept, e);
-            return new ResponseEntity<Object>(HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.INTERNAL_SERVER_ERROR);
         }
         catch (NothingFoundException e)
         {
         	log.warn("Could not find any matching reference(s) in database.");
-        	return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
         }
     }
     
@@ -221,22 +222,22 @@ public class MyCollectionsApiController extends MyProductsApiBareController impl
         catch (ApplicationTypeException e)
         {
         	log.error("Application type not implemented", e);
-        	return new ResponseEntity<Object>(HttpStatus.NOT_IMPLEMENTED);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
         }
         catch (IOException e)
         {
             log.error("Couldn't serialize response for content type " + accept, e);
-            return new ResponseEntity<Object>(HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.INTERNAL_SERVER_ERROR);
         }
         catch (LidVidNotFoundException e)
         {
             log.warn("Could not find lid(vid) in database: " + lidvid);
-            return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+            return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
         }
         catch (NothingFoundException e)
         {
         	log.warn("Could not find any matching reference(s) in database.");
-        	return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
         }
     }
     

--- a/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiBareController.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiBareController.java
@@ -25,6 +25,7 @@ import gov.nasa.pds.api.engineering.elasticsearch.ElasticSearchHitIterator;
 import gov.nasa.pds.api.engineering.elasticsearch.ElasticSearchRegistryConnection;
 import gov.nasa.pds.api.engineering.elasticsearch.ElasticSearchRegistrySearchRequestBuilder;
 import gov.nasa.pds.api.engineering.elasticsearch.business.RequestAndResponseContext;
+import gov.nasa.pds.api.engineering.elasticsearch.business.ErrorFactory;
 import gov.nasa.pds.api.engineering.elasticsearch.business.LidVidNotFoundException;
 import gov.nasa.pds.api.engineering.elasticsearch.business.LidVidUtils;
 import gov.nasa.pds.api.engineering.elasticsearch.business.ProductBusinessObject;
@@ -98,22 +99,22 @@ public class MyProductsApiBareController {
         catch (ApplicationTypeException e)
         {
         	log.error("Application type not implemented", e);
-        	return new ResponseEntity<Object>(HttpStatus.NOT_IMPLEMENTED);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
         }
         catch (IOException e)
         {
             log.error("Couldn't serialize response for content type " + accept, e);
-            return new ResponseEntity<Object>(HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.INTERNAL_SERVER_ERROR);
         }
         catch (NothingFoundException e)
         {
         	log.warn("Could not find any matching reference(s) in database.");
-        	return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
         }
         catch (ParseCancellationException pce)
         {
             log.error("Could not parse the query string: " + q, pce);
-            return new ResponseEntity<Object>(HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<Object>(ErrorFactory.build(pce, this.request), HttpStatus.BAD_REQUEST);
         }
     }    
     
@@ -133,22 +134,22 @@ public class MyProductsApiBareController {
         catch (ApplicationTypeException e)
         {
         	log.error("Application type not implemented", e);
-        	return new ResponseEntity<Object>(HttpStatus.NOT_IMPLEMENTED);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
         }
         catch (IOException e)
         {
             log.error("Couldn't serialize response for content type " + accept, e);
-            return new ResponseEntity<Object>(HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.INTERNAL_SERVER_ERROR);
         }
         catch (NothingFoundException e)
         {
         	log.warn("Could not find any matching reference(s) in database.");
-        	return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
         }
         catch (ParseCancellationException pce)
         {
             log.error("", pce);
-            return new ResponseEntity<Object>(HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<Object>(ErrorFactory.build(pce, this.request), HttpStatus.BAD_REQUEST);
         }
     }    
     
@@ -181,22 +182,22 @@ public class MyProductsApiBareController {
         catch (ApplicationTypeException e)
         {
         	log.error("Application type not implemented", e);
-        	return new ResponseEntity<Object>(HttpStatus.NOT_IMPLEMENTED);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
         }
         catch (IOException e) 
         {
             log.error("Couldn't get or serialize response for content type " + accept, e);
-            return new ResponseEntity<Object>(HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.INTERNAL_SERVER_ERROR);
         }
         catch (LidVidNotFoundException e)
         {
             log.warn("Could not find lid(vid) in database: " + lidvid);
-            return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+            return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
         }
         catch (NothingFoundException e)
         {
         	log.warn("Could not find any matching reference(s) in database.");
-        	return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
         }
     }
 
@@ -226,5 +227,4 @@ public class MyProductsApiBareController {
             return null;
         }
     }
-
 }

--- a/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiController.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiController.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.nasa.pds.api.base.ProductsApi;
 import gov.nasa.pds.api.engineering.elasticsearch.ElasticSearchHitIterator;
 import gov.nasa.pds.api.engineering.elasticsearch.ElasticSearchRegistrySearchRequestBuilder;
+import gov.nasa.pds.api.engineering.elasticsearch.business.ErrorFactory;
 import gov.nasa.pds.api.engineering.elasticsearch.business.LidVidNotFoundException;
 import gov.nasa.pds.api.engineering.elasticsearch.business.RequestAndResponseContext;
 import gov.nasa.pds.api.engineering.exceptions.ApplicationTypeException;
@@ -96,22 +97,22 @@ public class MyProductsApiController extends MyProductsApiBareController impleme
         catch (ApplicationTypeException e)
         {
         	log.error("Application type not implemented", e);
-        	return new ResponseEntity<Object>(HttpStatus.NOT_IMPLEMENTED);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
         }
         catch (IOException e)
         {
             log.error("Couldn't serialize response for content type " + accept, e);
-            return new ResponseEntity<Object>(HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.INTERNAL_SERVER_ERROR);
         }
         catch (LidVidNotFoundException e)
         {
             log.warn("Could not find lid(vid) in database: " + lidvid);
-            return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+            return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
         }
         catch (NothingFoundException e)
         {
         	log.warn("Could not find any matching reference(s) in database.");
-        	return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
         }
    }
 
@@ -148,22 +149,22 @@ public class MyProductsApiController extends MyProductsApiBareController impleme
         catch (ApplicationTypeException e)
         {
         	log.error("Application type not implemented", e);
-        	return new ResponseEntity<Object>(HttpStatus.NOT_IMPLEMENTED);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
         }
         catch (IOException e)
         {
             log.error("Couldn't serialize response for content type " + accept, e);
-            return new ResponseEntity<Object>(HttpStatus.INTERNAL_SERVER_ERROR);
+            return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.INTERNAL_SERVER_ERROR);
         }
         catch (LidVidNotFoundException e)
         {
             log.warn("Could not find lid(vid) in database: " + lidvid);
-            return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+            return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
         }
         catch (NothingFoundException e)
         {
         	log.warn("Could not find any matching reference(s) in database.");
-        	return new ResponseEntity<Object>(HttpStatus.NOT_FOUND);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
         }
     }
 

--- a/service/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/ErrorFactory.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/ErrorFactory.java
@@ -1,0 +1,16 @@
+package gov.nasa.pds.api.engineering.elasticsearch.business;
+
+import javax.servlet.http.HttpServletRequest;
+
+import gov.nasa.pds.model.ErrorMessage;
+
+public class ErrorFactory
+{
+	public static Object build(Exception err, HttpServletRequest request)
+	{
+		ErrorMessage em = new ErrorMessage();
+		em.setRequest(request.getRequestURI());
+		em.setMessage(err.getMessage());
+		return em;
+	}
+}

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/CsvErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/CsvErrorMessageSerializer.java
@@ -28,14 +28,17 @@ public class CsvErrorMessageSerializer extends AbstractHttpMessageConverter<Erro
 	protected void writeInternal(ErrorMessage t, HttpOutputMessage outputMessage)
 			throws IOException, HttpMessageNotWritableException
 	{
-		OutputStreamWriter writer = new OutputStreamWriter(outputMessage.getBody(), "UTF-8");
-		writer.write ("request,message\n");
-		writer.write('"');
-		writer.write(t.getRequest());
-		writer.write("\",\"");
-		writer.write(t.getMessage());
-		writer.write('"');
-		writer.write('\n');
-		writer.close();
+		OutputStreamWriter osw = new OutputStreamWriter(outputMessage.getBody(), "UTF-8");
+		try
+		{
+			osw.write ("request,message\n");
+			osw.write('"');
+			osw.write(t.getRequest());
+			osw.write("\",\"");
+			osw.write(t.getMessage());
+			osw.write('"');
+			osw.write('\n');
+		}
+		finally { osw.close(); }
 	}
 }

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/CsvErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/CsvErrorMessageSerializer.java
@@ -1,0 +1,41 @@
+package gov.nasa.pds.api.engineering.serializer;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+import gov.nasa.pds.model.ErrorMessage;
+
+public class CsvErrorMessageSerializer extends AbstractHttpMessageConverter<ErrorMessage>
+{
+	public CsvErrorMessageSerializer()
+	{ super(new MediaType("application","csv"), new MediaType("text","csv")); }
+
+	@Override
+	protected boolean supports(Class<?> clazz) { return ErrorMessage.class.isAssignableFrom(clazz); }
+
+	@Override
+	protected ErrorMessage readInternal(Class<? extends ErrorMessage> clazz, HttpInputMessage inputMessage)
+			throws IOException, HttpMessageNotReadableException { return new ErrorMessage(); }
+
+	@Override
+	protected void writeInternal(ErrorMessage t, HttpOutputMessage outputMessage)
+			throws IOException, HttpMessageNotWritableException
+	{
+		OutputStreamWriter writer = new OutputStreamWriter(outputMessage.getBody());
+		writer.write ("request,message\n");
+		writer.write('"');
+		writer.write(t.getRequest());
+		writer.write("\",\"");
+		writer.write(t.getMessage());
+		writer.write('"');
+		writer.write('\n');
+		writer.close();
+	}
+}

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/CsvErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/CsvErrorMessageSerializer.java
@@ -28,7 +28,7 @@ public class CsvErrorMessageSerializer extends AbstractHttpMessageConverter<Erro
 	protected void writeInternal(ErrorMessage t, HttpOutputMessage outputMessage)
 			throws IOException, HttpMessageNotWritableException
 	{
-		OutputStreamWriter writer = new OutputStreamWriter(outputMessage.getBody());
+		OutputStreamWriter writer = new OutputStreamWriter(outputMessage.getBody(), "UTF-8");
 		writer.write ("request,message\n");
 		writer.write('"');
 		writer.write(t.getRequest());

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/HtmlErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/HtmlErrorMessageSerializer.java
@@ -28,7 +28,7 @@ public class HtmlErrorMessageSerializer extends AbstractHttpMessageConverter<Err
 			throws IOException, HttpMessageNotWritableException
 	{
 		OutputStreamWriter osw = new OutputStreamWriter(outputMessage.getBody());
-		osw.write("<html><body<h1>Error Message</h1><h2>From Request</h2><p>");
+		osw.write("<html><body><h1>Error Message</h1><h2>From Request</h2><p>");
 		osw.write(t.getRequest());
 		osw.write("</p><h2>Message</h2><p>");
 		osw.write(t.getMessage());

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/HtmlErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/HtmlErrorMessageSerializer.java
@@ -27,7 +27,7 @@ public class HtmlErrorMessageSerializer extends AbstractHttpMessageConverter<Err
 	protected void writeInternal(ErrorMessage t, HttpOutputMessage outputMessage)
 			throws IOException, HttpMessageNotWritableException
 	{
-		OutputStreamWriter osw = new OutputStreamWriter(outputMessage.getBody());
+		OutputStreamWriter osw = new OutputStreamWriter(outputMessage.getBody(), "UTF-8");
 		osw.write("<html><body><h1>Error Message</h1><h2>From Request</h2><p>");
 		osw.write(t.getRequest());
 		osw.write("</p><h2>Message</h2><p>");

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/HtmlErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/HtmlErrorMessageSerializer.java
@@ -28,12 +28,15 @@ public class HtmlErrorMessageSerializer extends AbstractHttpMessageConverter<Err
 			throws IOException, HttpMessageNotWritableException
 	{
 		OutputStreamWriter osw = new OutputStreamWriter(outputMessage.getBody(), "UTF-8");
-		osw.write("<html><body><h1>Error Message</h1><h2>From Request</h2><p>");
-		osw.write(t.getRequest());
-		osw.write("</p><h2>Message</h2><p>");
-		osw.write(t.getMessage());
-		osw.write("</p></body></html>");
-		osw.close();
+		try
+		{
+			osw.write("<html><body><h1>Error Message</h1><h2>From Request</h2><p>");
+			osw.write(t.getRequest());
+			osw.write("</p><h2>Message</h2><p>");
+			osw.write(t.getMessage());
+			osw.write("</p></body></html>");
+		}
+		finally { osw.close(); }
 	}
 }
 

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/HtmlErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/HtmlErrorMessageSerializer.java
@@ -1,0 +1,40 @@
+package gov.nasa.pds.api.engineering.serializer;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+import gov.nasa.pds.model.ErrorMessage;
+
+public class HtmlErrorMessageSerializer extends AbstractHttpMessageConverter<ErrorMessage>
+{
+	public HtmlErrorMessageSerializer() { super (MediaType.TEXT_HTML); }
+
+	@Override
+	protected boolean supports(Class<?> clazz) { return ErrorMessage.class.isAssignableFrom(clazz); }
+
+	@Override
+	protected ErrorMessage readInternal(Class<? extends ErrorMessage> clazz, HttpInputMessage inputMessage)
+			throws IOException, HttpMessageNotReadableException { return new ErrorMessage(); }
+
+	@Override
+	protected void writeInternal(ErrorMessage t, HttpOutputMessage outputMessage)
+			throws IOException, HttpMessageNotWritableException
+	{
+		OutputStreamWriter osw = new OutputStreamWriter(outputMessage.getBody());
+		osw.write("<html><body<h1>Error Message</h1><h2>From Request</h2><p>");
+		osw.write(t.getRequest());
+		osw.write("</p><h2>Message</h2><p>");
+		osw.write(t.getMessage());
+		osw.write("</p></body></html>");
+		osw.close();
+	}
+}
+
+	

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/JsonErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/JsonErrorMessageSerializer.java
@@ -30,12 +30,15 @@ public class JsonErrorMessageSerializer extends AbstractHttpMessageConverter<Err
 	protected void writeInternal(ErrorMessage t, HttpOutputMessage outputMessage)
 			throws IOException, HttpMessageNotWritableException
 	{
-        OutputStreamWriter wr = new OutputStreamWriter(outputMessage.getBody(), "UTF-8");
-        wr.write("{\"request\":\"");
-        wr.write(t.getRequest());
-        wr.write("\",\"message\":\"");
-        wr.write(t.getMessage());
-        wr.write("\"}");
-        wr.close();
+        OutputStreamWriter osw = new OutputStreamWriter(outputMessage.getBody(), "UTF-8");
+        try
+        {
+        	osw.write("{\"request\":\"");
+        	osw.write(t.getRequest());
+        	osw.write("\",\"message\":\"");
+        	osw.write(t.getMessage());
+        	osw.write("\"}");
+        }
+        finally { osw.close(); }
 	}
 }

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/JsonErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/JsonErrorMessageSerializer.java
@@ -30,7 +30,7 @@ public class JsonErrorMessageSerializer extends AbstractHttpMessageConverter<Err
 	protected void writeInternal(ErrorMessage t, HttpOutputMessage outputMessage)
 			throws IOException, HttpMessageNotWritableException
 	{
-        OutputStreamWriter wr = new OutputStreamWriter(outputMessage.getBody());
+        OutputStreamWriter wr = new OutputStreamWriter(outputMessage.getBody(), "UTF-8");
         wr.write("{\"request\":\"");
         wr.write(t.getRequest());
         wr.write("\",\"message\":\"");

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/JsonErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/JsonErrorMessageSerializer.java
@@ -1,0 +1,41 @@
+package gov.nasa.pds.api.engineering.serializer;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+import gov.nasa.pds.model.ErrorMessage;
+
+public class JsonErrorMessageSerializer extends AbstractHttpMessageConverter<ErrorMessage>
+{
+	public JsonErrorMessageSerializer()
+	{ super(MediaType.APPLICATION_JSON,
+			new MediaType("application","kvp+json"),
+			new MediaType("application", "pds4+json")); }
+
+	@Override
+	protected boolean supports(Class<?> clazz) { return ErrorMessage.class.isAssignableFrom(clazz); }
+
+	@Override
+	protected ErrorMessage readInternal(Class<? extends ErrorMessage> clazz, HttpInputMessage inputMessage)
+			throws IOException, HttpMessageNotReadableException { return new ErrorMessage(); }
+
+	@Override
+	protected void writeInternal(ErrorMessage t, HttpOutputMessage outputMessage)
+			throws IOException, HttpMessageNotWritableException
+	{
+        OutputStreamWriter wr = new OutputStreamWriter(outputMessage.getBody());
+        wr.write("{\"request\":\"");
+        wr.write(t.getRequest());
+        wr.write("\",\"message\":\"");
+        wr.write(t.getMessage());
+        wr.write("\"}");
+        wr.close();
+	}
+}

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/XmlErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/XmlErrorMessageSerializer.java
@@ -28,7 +28,7 @@ public class XmlErrorMessageSerializer extends AbstractHttpMessageConverter<Erro
 	protected void writeInternal(ErrorMessage t, HttpOutputMessage outputMessage)
 			throws IOException, HttpMessageNotWritableException
 	{
-		OutputStreamWriter osw = new OutputStreamWriter(outputMessage.getBody());
+		OutputStreamWriter osw = new OutputStreamWriter(outputMessage.getBody(), "UTF-8");
 		osw.write("<error><request>");
 		osw.write(t.getRequest());
 		osw.write("</request><message>");

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/XmlErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/XmlErrorMessageSerializer.java
@@ -29,11 +29,14 @@ public class XmlErrorMessageSerializer extends AbstractHttpMessageConverter<Erro
 			throws IOException, HttpMessageNotWritableException
 	{
 		OutputStreamWriter osw = new OutputStreamWriter(outputMessage.getBody(), "UTF-8");
-		osw.write("<error><request>");
-		osw.write(t.getRequest());
-		osw.write("</request><message>");
-		osw.write(t.getMessage());
-		osw.write("</message></error>");
-		osw.close();
+		try
+		{
+			osw.write("<error><request>");
+			osw.write(t.getRequest());
+			osw.write("</request><message>");
+			osw.write(t.getMessage());
+			osw.write("</message></error>");
+		}
+		finally { osw.close(); }
 	}
 }

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/XmlErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/XmlErrorMessageSerializer.java
@@ -1,0 +1,39 @@
+package gov.nasa.pds.api.engineering.serializer;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+import gov.nasa.pds.model.ErrorMessage;
+
+public class XmlErrorMessageSerializer extends AbstractHttpMessageConverter<ErrorMessage>
+{
+	public XmlErrorMessageSerializer()
+	{ super(MediaType.APPLICATION_XML, MediaType.TEXT_XML, new MediaType("application", "pds4+xml")); }
+
+	@Override
+	protected boolean supports(Class<?> clazz) { return ErrorMessage.class.isAssignableFrom(clazz); }
+
+	@Override
+	protected ErrorMessage readInternal(Class<? extends ErrorMessage> clazz, HttpInputMessage inputMessage)
+			throws IOException, HttpMessageNotReadableException { return new ErrorMessage(); }
+
+	@Override
+	protected void writeInternal(ErrorMessage t, HttpOutputMessage outputMessage)
+			throws IOException, HttpMessageNotWritableException
+	{
+		OutputStreamWriter osw = new OutputStreamWriter(outputMessage.getBody());
+		osw.write("<error><request>");
+		osw.write(t.getRequest());
+		osw.write("</request><message>");
+		osw.write(t.getMessage());
+		osw.write("</message></error>");
+		osw.close();
+	}
+}


### PR DESCRIPTION
## 🗒️ Summary
Now returns error messages as result when things go awry.

## ⚙️ Test Data and/or Report
```
$ curl --location --request GET 'http://localhost:8080/products/urn:nasa:pds:izenberg_pdart14_meap:document:ns_in::1.0' 
{"request":"/products/urn:nasa:pds:izenberg_pdart14_meap:document:ns_in::1.0","message":"The lidvid urn:nasa:pds:izenberg_pdart14_meap:document:ns_in was not found"}


$ curl --location --request GET 'http://localhost:8080/products/urn:nasa:pds:izenberg_pdart14_meap:document:ns_in::1.0'  --header 'Accept:text/xml'
<error><request>/products/urn:nasa:pds:izenberg_pdart14_meap:document:ns_in::1.0</request><message>The lidvid urn:nasa:pds:izenberg_pdart14_meap:document:ns_in was not found</message></error>
```

## ♻️ Related Issues
NASA-PDS/registry-api#443
