### PR TITLE
issue #93: add pds_api namespace

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4XmlProductSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4XmlProductSerializer.java
@@ -1,5 +1,6 @@
 package gov.nasa.pds.api.engineering.serializer;
 
+import gov.nasa.pds.api.model.xml.NamespaceXmlFactory;
 import gov.nasa.pds.model.Pds4Product;
 
 import java.io.IOException;
@@ -51,7 +52,7 @@ public class Pds4XmlProductSerializer extends AbstractHttpMessageConverter<Pds4P
 			writer.writeStartElement(Pds4XmlProductSerializer.NAMESPACE_URL, "product");
 			writer.writeNamespace(Pds4XmlProductSerializer.NAMESPACE_PREFIX, 
 	        		  Pds4XmlProductSerializer.NAMESPACE_URL);
-			Pds4XmlProductSerializer.serialize(outputStream, writer, new XmlMapper(), product);
+			Pds4XmlProductSerializer.serialize(outputStream, writer, new XmlMapper(new NamespaceXmlFactory()), product);
 			writer.writeEndElement();
 			writer.close();
 		}
@@ -69,7 +70,9 @@ public class Pds4XmlProductSerializer extends AbstractHttpMessageConverter<Pds4P
 		writer.writeStartElement(Pds4XmlProductSerializer.NAMESPACE_URL, "meta");
 		writer.writeCharacters("");
 		writer.flush();
-		stream.write(mapper.writeValueAsString(product.getMetadata()).replace("<Pds4Metadata>","").replace("</Pds4Metadata>","").getBytes("UTF-8"));
+		stream.write(mapper.writeValueAsString(product.getMetadata())
+				.replace("<pds_api:Pds4Metadata xmlns:pds_api=\"http://pds.nasa.gov/api\">","")
+				.replace("</pds_api:Pds4Metadata>","").getBytes("UTF-8"));
 		stream.flush();
 		writer.writeEndElement();
 		writer.writeStartElement(Pds4XmlProductSerializer.NAMESPACE_URL, "pds4");

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4XmlProductsSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4XmlProductsSerializer.java
@@ -17,6 +17,7 @@ import org.springframework.http.converter.HttpMessageNotWritableException;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
+import gov.nasa.pds.api.model.xml.NamespaceXmlFactory;
 import gov.nasa.pds.model.Pds4Product;
 import gov.nasa.pds.model.Pds4Products;
 import gov.nasa.pds.model.Summary;
@@ -67,7 +68,7 @@ public class Pds4XmlProductsSerializer  extends AbstractHttpMessageConverter<Pds
 	          writer.writeStartElement(Pds4XmlProductSerializer.NAMESPACE_URL, "data");
 	          for (Pds4Product product : products.getData()) {
 	        	  writer.writeStartElement(Pds4XmlProductSerializer.NAMESPACE_URL, "product");
-		          Pds4XmlProductSerializer.serialize (outputStream, writer, xmlMapper, product);
+		          Pds4XmlProductSerializer.serialize (outputStream, writer, new XmlMapper(new NamespaceXmlFactory()), product);
 		          writer.writeEndElement();
 	          }
 	          writer.writeEndElement(); // data

--- a/service/src/main/java/gov/nasa/pds/api/model/xml/NamespaceXmlFactory.java
+++ b/service/src/main/java/gov/nasa/pds/api/model/xml/NamespaceXmlFactory.java
@@ -1,0 +1,32 @@
+package gov.nasa.pds.api.model.xml;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.dataformat.xml.XmlFactory;
+
+import gov.nasa.pds.api.engineering.serializer.Pds4XmlProductSerializer;
+
+public class NamespaceXmlFactory extends XmlFactory
+{
+	private static final Logger log = LoggerFactory.getLogger(NamespaceXmlFactory.class);
+	private static final long serialVersionUID = 1L;
+
+    public NamespaceXmlFactory() {}
+
+    @Override
+    protected XMLStreamWriter _createXmlWriter(IOContext ctxt, Writer w) throws IOException
+    {
+        XMLStreamWriter writer = super._createXmlWriter(ctxt, w);
+        try { writer.setPrefix(Pds4XmlProductSerializer.NAMESPACE_PREFIX, Pds4XmlProductSerializer.NAMESPACE_URL); }
+        catch (XMLStreamException e) { log.error("Could not set the namespace prefix", e); }
+        return new XMLStreamWriterWithNamespace(writer);
+    }
+}

--- a/service/src/main/java/gov/nasa/pds/api/model/xml/XMLStreamWriterWithNamespace.java
+++ b/service/src/main/java/gov/nasa/pds/api/model/xml/XMLStreamWriterWithNamespace.java
@@ -6,7 +6,7 @@ import javax.xml.stream.XMLStreamWriter;
 
 import gov.nasa.pds.api.engineering.serializer.Pds4XmlProductSerializer;
 
-public class XMLStreamWriterWithNamespace implements XMLStreamWriter
+class XMLStreamWriterWithNamespace implements XMLStreamWriter
 {
 	final private XMLStreamWriter actual;
 

--- a/service/src/main/java/gov/nasa/pds/api/model/xml/XMLStreamWriterWithNamespace.java
+++ b/service/src/main/java/gov/nasa/pds/api/model/xml/XMLStreamWriterWithNamespace.java
@@ -1,0 +1,123 @@
+package gov.nasa.pds.api.model.xml;
+
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import gov.nasa.pds.api.engineering.serializer.Pds4XmlProductSerializer;
+
+public class XMLStreamWriterWithNamespace implements XMLStreamWriter
+{
+	final private XMLStreamWriter actual;
+
+	public XMLStreamWriterWithNamespace (XMLStreamWriter actual) { this.actual = actual; }
+
+	@Override
+	public void close() throws XMLStreamException { this.actual.close(); }
+
+	@Override
+	public void flush() throws XMLStreamException { this.actual.flush(); }
+
+	@Override
+	public NamespaceContext getNamespaceContext() { return this.actual.getNamespaceContext(); }
+
+	@Override
+	public String getPrefix(String uri) throws XMLStreamException { return this.actual.getPrefix(uri); }
+
+	@Override
+	public Object getProperty(String name) throws IllegalArgumentException { return this.actual.getProperty(name); }
+
+	@Override
+	public void setDefaultNamespace(String uri) throws XMLStreamException { this.actual.setDefaultNamespace(uri); }
+
+	@Override
+	public void setNamespaceContext(NamespaceContext context) throws XMLStreamException { this.actual.setNamespaceContext(context); }
+
+	@Override
+	public void setPrefix(String arg0, String arg1) throws XMLStreamException { this.actual.setPrefix(arg0, arg1); }
+
+	@Override
+	public void writeAttribute(String arg0, String arg1) throws XMLStreamException
+	{ this.actual.writeAttribute(Pds4XmlProductSerializer.NAMESPACE_URL, arg0, arg1); }
+
+	@Override
+	public void writeAttribute(String arg0, String arg1, String arg2) throws XMLStreamException
+	{ this.actual.writeAttribute(arg0, arg1, arg2); }
+
+	@Override
+	public void writeAttribute(String arg0, String arg1, String arg2, String arg3) throws XMLStreamException
+	{ this.actual.writeAttribute(arg0, arg1, arg2, arg3); }
+
+	@Override
+	public void writeCData(String data) throws XMLStreamException { this.actual.writeCData(data); }
+
+	@Override
+	public void writeCharacters(String text) throws XMLStreamException { this.actual.writeCharacters(text); }
+
+	@Override
+	public void writeCharacters(char[] arg0, int arg1, int arg2) throws XMLStreamException
+	{ this.actual.writeCharacters(arg0, arg1, arg2); }
+
+	@Override
+	public void writeComment(String data) throws XMLStreamException { this.actual.writeComment(data); }
+
+	@Override
+	public void writeDTD(String dtd) throws XMLStreamException { this.actual.writeDTD(dtd); }
+
+	@Override
+	public void writeDefaultNamespace(String namespaceURI) throws XMLStreamException { this.actual.writeDefaultNamespace(namespaceURI); }
+
+	@Override
+	public void writeEmptyElement(String localName) throws XMLStreamException
+	{ this.actual.writeEmptyElement(Pds4XmlProductSerializer.NAMESPACE_URL, localName); }
+
+	@Override
+	public void writeEmptyElement(String arg0, String arg1) throws XMLStreamException { this.actual.writeEmptyElement(arg0, arg1); }
+
+	@Override
+	public void writeEmptyElement(String arg0, String arg1, String arg2) throws XMLStreamException { this.actual.writeEmptyElement(arg0, arg1, arg2); }
+
+	@Override
+	public void writeEndDocument() throws XMLStreamException { this.actual.writeEndDocument(); }
+
+	@Override
+	public void writeEndElement() throws XMLStreamException { this.actual.writeEndElement(); }
+
+	@Override
+	public void writeEntityRef(String name) throws XMLStreamException { this.actual.writeEntityRef(name); }
+
+	@Override
+	public void writeNamespace(String arg0, String arg1) throws XMLStreamException 
+	{ this.actual.writeNamespace(arg0, arg1); }
+
+	@Override
+	public void writeProcessingInstruction(String target) throws XMLStreamException 
+	{ this.actual.writeProcessingInstruction(target); }
+
+	@Override
+	public void writeProcessingInstruction(String arg0, String arg1) throws XMLStreamException
+	{ this.actual.writeProcessingInstruction(arg0, arg1); }
+
+	@Override
+	public void writeStartDocument() throws XMLStreamException { this.actual.writeStartDocument(); }
+
+	@Override
+	public void writeStartDocument(String version) throws XMLStreamException { this.actual.writeStartDocument(version); }
+
+	@Override
+	public void writeStartDocument(String arg0, String arg1) throws XMLStreamException
+	{ this.actual.writeStartDocument(arg0, arg1); }
+
+	@Override
+	public void writeStartElement(String localName) throws XMLStreamException
+	{ this.actual.writeStartElement(Pds4XmlProductSerializer.NAMESPACE_URL,localName); }
+
+	@Override
+	public void writeStartElement(String arg0, String arg1) throws XMLStreamException
+	{ this.actual.writeStartElement(Pds4XmlProductSerializer.NAMESPACE_URL, arg1);}
+
+	@Override
+	public void writeStartElement(String arg0, String arg1, String arg2) throws XMLStreamException
+	{ this.actual.writeStartElement(arg0, arg1, arg2); }
+
+}


### PR DESCRIPTION
## 🗒️ Summary
Cannot update the beans generated by swagger easily so overrode the XmlMapper writer creation to add it instead. Required wrapping up XMLStreamWriter so force namespace usage.

## ⚙️ Test Data and/or Report
```
$ curl --location --request GET 'http://localhost:8080/products/urn:nasa:pds:izenberg_pdart14_meap:document:ns_inst::1.0' --header 'Accept: application/pds4+xml' | xmllint --format -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4427    0  4427    0     0  13496      0 --:--:-- --:--:-- --:--:-- 13496
<?xml version="1.0"?>
<pds_api:product xmlns:pds_api="http://pds.nasa.gov/api">
  <pds_api:id>urn:nasa:pds:izenberg_pdart14_meap:document:ns_inst::1.0</pds_api:id>
  <pds_api:meta>
    <pds_api:node_name>PSA</pds_api:node_name>
    <pds_api:label_file>
      <pds_api:file_name>ns_inst.xml</pds_api:file_name>
      <pds_api:file_ref>/var/local/harvest/archive/document/ns_inst.xml</pds_api:file_ref>
      <pds_api:creation_date>2022-01-24T20:08:23Z</pds_api:creation_date>
      <pds_api:file_size>3589</pds_api:file_size>
      <pds_api:md5_checksum>a8d09cca0a01728db50c15052c2736cf</pds_api:md5_checksum>
    </pds_api:label_file>
    <pds_api:data_files>
      <pds_api:data_files>
        <pds_api:file_name>ns_inst.pdf</pds_api:file_name>
        <pds_api:file_ref>/var/local/harvest/archive/document/ns_inst.pdf</pds_api:file_ref>
        <pds_api:creation_date>2022-01-24T20:08:23Z</pds_api:creation_date>
        <pds_api:file_size>138172</pds_api:file_size>
        <pds_api:md5_checksum>8103f20c13a3c321dac4a193aba19d16</pds_api:md5_checksum>
        <pds_api:mime_type>application/pdf</pds_api:mime_type>
      </pds_api:data_files>
    </pds_api:data_files>
  </pds_api:meta>
  <pds_api:pds4>
    <Product_Document xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1E00.xsd">
      <Identification_Area>
        <logical_identifier>urn:nasa:pds:izenberg_pdart14_meap:document:ns_inst</logical_identifier>
        <version_id>1.0</version_id>
        <title>MESSENGER Neutron Spectrometer (NS) Description</title>
        <information_model_version>1.14.0.0</information_model_version>
        <product_class>Product_Document</product_class>
        <Citation_Information>
          <publication_year>2016</publication_year>
          <description>Description of the MESSENGER Neutron Spectrometer (NS).</description>
        </Citation_Information>
        <Modification_History>
          <Modification_Detail>
            <modification_date>2016-03-16</modification_date>
            <version_id>1.0</version_id>
            <description>Initial PDS4 version.</description>
          </Modification_Detail>
        </Modification_History>
      </Identification_Area>
      <Context_Area>
        <Investigation_Area>
          <name>MESSENGER</name>
          <type>Mission</type>
          <Internal_Reference>
            <lid_reference>urn:nasa:pds:context:investigation:mission.messenger</lid_reference>
            <reference_type>document_to_investigation</reference_type>
          </Internal_Reference>
        </Investigation_Area>
        <Observing_System>
          <name>MESSENGER</name>
          <Observing_System_Component>
            <name>MESSENGER</name>
            <type>Host</type>
            <Internal_Reference>
              <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.mess</lid_reference>
              <reference_type>is_instrument_host</reference_type>
            </Internal_Reference>
          </Observing_System_Component>
          <Observing_System_Component>
            <name>NS</name>
            <type>Instrument</type>
            <Internal_Reference>
              <lid_reference>urn:nasa:pds:context:instrument:ns.mess</lid_reference>
              <reference_type>is_instrument</reference_type>
            </Internal_Reference>
          </Observing_System_Component>
        </Observing_System>
        <Target_Identification>
          <name>Mercury</name>
          <type>Planet</type>
          <Internal_Reference>
            <lid_reference>urn:nasa:pds:context:target:planet.mercury</lid_reference>
            <reference_type>document_to_target</reference_type>
          </Internal_Reference>
        </Target_Identification>
      </Context_Area>
      <Document>
        <publication_date>2016-03-16</publication_date>
        <description>Description of the MESSENGER Neutron Spectrometer (NS).</description>
        <Document_Edition>
          <edition_name>MESSENGER NS Instrument Description</edition_name>
          <language>English</language>
          <files>1</files>
          <Document_File>
            <file_name>ns_inst.pdf</file_name>
            <document_standard_id>PDF/A</document_standard_id>
          </Document_File>
        </Document_Edition>
      </Document>
    </Product_Document>
  </pds_api:pds4>
</pds_api:product>
```
## ♻️ Related Issues

Resolves #93 