### PR TITLE
pds api 127: improved error messaging

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyBundlesApiController.java
@@ -166,7 +166,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
          catch (ApplicationTypeException e)
          {
         	 log.error("Application type not implemented", e);
-        	 return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
+        	 return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_ACCEPTABLE);
          }
          catch (IOException e)
          {
@@ -202,7 +202,7 @@ public class MyBundlesApiController extends MyProductsApiBareController implemen
          catch (ApplicationTypeException e)
          {
         	 log.error("Application type not implemented", e);
-        	 return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
+        	 return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_ACCEPTABLE);
          }
          catch (IOException e)
          {

--- a/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyCollectionsApiController.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyCollectionsApiController.java
@@ -135,7 +135,7 @@ public class MyCollectionsApiController extends MyProductsApiBareController impl
         catch (ApplicationTypeException e)
         {
         	log.error("Application type not implemented", e);
-       	 	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
+       	 	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_ACCEPTABLE);
         }
         catch (LidVidNotFoundException e)
         {
@@ -222,7 +222,7 @@ public class MyCollectionsApiController extends MyProductsApiBareController impl
         catch (ApplicationTypeException e)
         {
         	log.error("Application type not implemented", e);
-        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_ACCEPTABLE);
         }
         catch (IOException e)
         {

--- a/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiBareController.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiBareController.java
@@ -99,7 +99,7 @@ public class MyProductsApiBareController {
         catch (ApplicationTypeException e)
         {
         	log.error("Application type not implemented", e);
-        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_ACCEPTABLE);
         }
         catch (IOException e)
         {
@@ -134,7 +134,7 @@ public class MyProductsApiBareController {
         catch (ApplicationTypeException e)
         {
         	log.error("Application type not implemented", e);
-        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_ACCEPTABLE);
         }
         catch (IOException e)
         {
@@ -182,7 +182,7 @@ public class MyProductsApiBareController {
         catch (ApplicationTypeException e)
         {
         	log.error("Application type not implemented", e);
-        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_ACCEPTABLE);
         }
         catch (IOException e) 
         {

--- a/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiController.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/controllers/MyProductsApiController.java
@@ -97,7 +97,7 @@ public class MyProductsApiController extends MyProductsApiBareController impleme
         catch (ApplicationTypeException e)
         {
         	log.error("Application type not implemented", e);
-        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_ACCEPTABLE);
         }
         catch (IOException e)
         {
@@ -149,7 +149,7 @@ public class MyProductsApiController extends MyProductsApiBareController impleme
         catch (ApplicationTypeException e)
         {
         	log.error("Application type not implemented", e);
-        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_IMPLEMENTED);
+        	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_ACCEPTABLE);
         }
         catch (IOException e)
         {

--- a/service/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/RequestAndResponseContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/RequestAndResponseContext.java
@@ -161,17 +161,9 @@ public class RequestAndResponseContext
 		}
 		else
 		{
-			String known = "";
-			log.warn("Could not find a matach for application type: " + String.valueOf(this.format));
-			log.warn("   Known types: " + String.valueOf(this.formatters.keySet().size()));
-			for (String key : this.formatters.keySet())
-			{
-				log.warn("      key: " + String.valueOf(key));
-				known = known + key + ",";
-			}
-			known = known.substring(0, known.length()-1);
-			throw new ApplicationTypeException("The given application type, " + String.valueOf(this.format) +
-					                           ", is not known by RquestAndResponseContext. Known choices are: " + known);
+                    String known = String.join(", ", this.formatters.keySet());
+			log.warn("The Accept header value " + String.valueOf(this.format) + " is not supported, supported values are " + known);
+			throw new ApplicationTypeException("The Accept header value " + String.valueOf(this.format) + " is not supported, supported values are " + known);
 		}
 
 		/* if the URL contains fields, then make sure the minimum was included too OR there is maximum set. */

--- a/service/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/RequestAndResponseContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/RequestAndResponseContext.java
@@ -161,10 +161,17 @@ public class RequestAndResponseContext
 		}
 		else
 		{
+			String known = "";
 			log.warn("Could not find a matach for application type: " + String.valueOf(this.format));
 			log.warn("   Known types: " + String.valueOf(this.formatters.keySet().size()));
-			for (String key : this.formatters.keySet()) log.warn("      key: " + String.valueOf(key));
-			throw new ApplicationTypeException("The given application type, " + String.valueOf(this.format) + ", is not known by RquestAndResponseContext.");
+			for (String key : this.formatters.keySet())
+			{
+				log.warn("      key: " + String.valueOf(key));
+				known = known + key + ",";
+			}
+			known = known.substring(0, known.length()-1);
+			throw new ApplicationTypeException("The given application type, " + String.valueOf(this.format) +
+					                           ", is not known by RquestAndResponseContext. Known choices are: " + known);
 		}
 
 		/* if the URL contains fields, then make sure the minimum was included too OR there is maximum set. */

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/JsonErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/JsonErrorMessageSerializer.java
@@ -17,7 +17,8 @@ public class JsonErrorMessageSerializer extends AbstractHttpMessageConverter<Err
 	public JsonErrorMessageSerializer()
 	{ super(MediaType.APPLICATION_JSON,
 			new MediaType("application","kvp+json"),
-			new MediaType("application", "pds4+json")); }
+			new MediaType("application", "pds4+json"),
+			MediaType.ALL); }
 
 	@Override
 	protected boolean supports(Class<?> clazz) { return ErrorMessage.class.isAssignableFrom(clazz); }


### PR DESCRIPTION
## 🗒️ Summary
Changed all of the AcceptTypeException to return 406 instead of 501.

Improved the message for the exception to include all of the known Accept: content types allowed.

Note, if a Accept: content type is not supported, then the result always comes out as JSON. If the request was 'Accept: text/htlm' then the chosen serializer is JSON.

## ⚙️ Test Data and/or Report
```
$ curl --location --request GET 'http://localhost:8080/products/urn:nasa:pds:izenberg_pdart14_meap:document:ns_ins::1.0' --header 'Accept: text/html'
<html><body><h1>Error Message</h1><h2>From Request</h2><p>/products/urn:nasa:pds:izenberg_pdart14_meap:document:ns_ins::1.0</p><h2>Message</h2><p>The lidvid urn:nasa:pds:izenberg_pdart14_meap:document:ns_ins was not found</p></body></html>
```

```
$ curl --location --request GET 'http://localhost:8080/products/urn:nasa:pds:izenberg_pdart14_meap:document:ns_inst::1.0' --header 'Accept: text/htmls'
{"request":"/products/urn:nasa:pds:izenberg_pdart14_meap:document:ns_inst::1.0","message":"The given application type, text/htmls, is not known by RquestAndResponseContext. Known choices are: application/csv,application/xml,text/html,application/json,*/*,application/pds4+xml,text/csv,text/xml,application/kvp+json,application/pds4+json"}
```

## ♻️ Related Issues

NASA-PDS/registry-api#446


