### PR TITLE
pds api 152: update to vendor tree

### DIFF
--- a/model/swagger.yml
+++ b/model/swagger.yml
@@ -69,7 +69,7 @@ paths:
             type: string
         - name: fields
           in: query
-          description: returned fields, syntax field0,field1 but does not impact pds4+json and pds4+xml output formats
+          description: returned fields, syntax field0,field1 but does not impact vnd.nasa.pds.pds4+json and vnd.nasa.pds.pds4+xml output formats
           required: false
           schema:
             type: array
@@ -216,7 +216,7 @@ paths:
           default: 100
       - name: fields
         in: query
-        description: returned fields, syntax field0,field1 but does not impact pds4+json and pds4+xml output formats
+        description: returned fields, syntax field0,field1 but does not impact vnd.nasa.pds.pds4+json and vnd.nasa.pds.pds4+xml output formats
         required: false
         schema:
           type: array
@@ -277,7 +277,7 @@ paths:
           default: 100
       - name: fields
         in: query
-        description: returned fields, syntax field0,field1 but does not impact pds4+json and pds4+xml output formats
+        description: returned fields, syntax field0,field1 but does not impact vnd.nasa.pds.pds4+json and vnd.nasa.pds.pds4+xml output formats
         required: false
         schema:
           type: array
@@ -345,7 +345,7 @@ paths:
             type: string
         - name: fields
           in: query
-          description: returned fields, syntax field0,field1 but does not impact pds4+json and pds4+xml output formats
+          description: returned fields, syntax field0,field1 but does not impact vnd.nasa.pds.pds4+json and vnd.nasa.pds.pds4+xml output formats
           required: false
           schema:
             type: array
@@ -492,7 +492,7 @@ paths:
           default: 100
       - name: fields
         in: query
-        description: returned fields, syntax field0,field1 but does not impact pds4+json and pds4+xml output formats
+        description: returned fields, syntax field0,field1 but does not impact vnd.nasa.pds.pds4+json and vnd.nasa.pds.pds4+xml output formats
         required: false
         schema:
           type: array
@@ -553,7 +553,7 @@ paths:
           default: 100
       - name: fields
         in: query
-        description: returned fields, syntax field0,field1 but does not impact pds4+json and pds4+xml output formats
+        description: returned fields, syntax field0,field1 but does not impact vnd.nasa.pds.pds4+json and vnd.nasa.pds.pds4+xml output formats
         required: false
         schema:
           type: array
@@ -614,7 +614,7 @@ paths:
           default: 100
       - name: fields
         in: query
-        description: returned fields, syntax field0,field1 but does not impact pds4+json and pds4+xml output formats
+        description: returned fields, syntax field0,field1 but does not impact vnd.nasa.pds.pds4+json and vnd.nasa.pds.pds4+xml output formats
         required: false
         schema:
           type: array
@@ -675,7 +675,7 @@ paths:
           default: 100
       - name: fields
         in: query
-        description: returned fields, syntax field0,field1 but does not impact pds4+json and pds4+xml output formats
+        description: returned fields, syntax field0,field1 but does not impact vnd.nasa.pds.pds4+json and vnd.nasa.pds.pds4+xml output formats
         required: false
         schema:
           type: array
@@ -743,7 +743,7 @@ paths:
             type: string
         - name: fields
           in: query
-          description: returned fields, syntax field0,field1 but does not impact pds4+json and pds4+xml output formats
+          description: returned fields, syntax field0,field1 but does not impact vnd.nasa.pds.pds4+json and vnd.nasa.pds.pds4+xml output formats
           required: false
           schema:
             type: array
@@ -890,7 +890,7 @@ paths:
           default: 100
       - name: fields
         in: query
-        description: returned fields, syntax field0,field1 but does not impact pds4+json and pds4+xml output formats
+        description: returned fields, syntax field0,field1 but does not impact vnd.nasa.pds.pds4+json and vnd.nasa.pds.pds4+xml output formats
         required: false
         schema:
           type: array
@@ -951,7 +951,7 @@ paths:
           default: 100
       - name: fields
         in: query
-        description: returned fields, syntax field0,field1 but does not impact pds4+json and pds4+xml output formats
+        description: returned fields, syntax field0,field1 but does not impact vnd.nasa.pds.pds4+json and vnd.nasa.pds.pds4+xml output formats
         required: false
         schema:
           type: array
@@ -1012,7 +1012,7 @@ paths:
           default: 100
       - name: fields
         in: query
-        description: returned fields, syntax field0,field1 but does not impact pds4+json and pds4+xml output formats
+        description: returned fields, syntax field0,field1 but does not impact vnd.nasa.pds.pds4+json and vnd.nasa.pds.pds4+xml output formats
         required: false
         schema:
           type: array
@@ -1073,7 +1073,7 @@ paths:
           default: 100
       - name: fields
         in: query
-        description: returned fields, syntax field0,field1 but does not impact pds4+json and pds4+xml output formats
+        description: returned fields, syntax field0,field1 but does not impact vnd.nasa.pds.pds4+json and vnd.nasa.pds.pds4+xml output formats
         required: false
         schema:
           type: array
@@ -1118,10 +1118,10 @@ components:
         application/kvp+json:
           schema:
             $ref: '#/components/schemas/errorMessage'
-        application/pds4+json:
+        application/vnd.nasa.pds.pds4+json:
           schema:
             $ref: '#/components/schemas/errorMessage'
-        application/pds4+xml:
+        application/vnd.nasa.pds.pds4+xml:
           schema:
             $ref: '#/components/schemas/errorMessage'
         application/xml:
@@ -1154,10 +1154,10 @@ components:
         application/kvp+json:
           schema:
             $ref: '#/components/schemas/wyriwygProducts'
-        application/pds4+json:
+        application/vnd.nasa.pds.pds4+json:
           schema:
             $ref: '#/components/schemas/pds4Products'
-        application/pds4+xml:
+        application/vnd.nasa.pds.pds4+xml:
           schema:
             $ref: '#/components/schemas/pds4Products'
         application/xml:
@@ -1190,10 +1190,10 @@ components:
         application/kvp+json:
           schema:
             $ref: '#/components/schemas/wyriwygProduct'
-        application/pds4+json:
+        application/vnd.nasa.pds.pds4+json:
           schema:
             $ref: '#/components/schemas/pds4Product'
-        application/pds4+xml:
+        application/vnd.nasa.pds.pds4+xml:
           schema:
             $ref: '#/components/schemas/pds4Product'
         application/xml:

--- a/service/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/RequestAndResponseContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/RequestAndResponseContext.java
@@ -112,8 +112,8 @@ public class RequestAndResponseContext
     	formatters.put("application/csv", new WyriwygBusinessObject());
     	formatters.put("application/json", new PdsProductBusinessObject());
     	formatters.put("application/kvp+json", new WyriwygBusinessObject());
-    	formatters.put("application/pds4+json", new Pds4ProductBusinessObject(true));
-    	formatters.put("application/pds4+xml", new Pds4ProductBusinessObject(false));
+    	formatters.put("application/vnd.nasa.pds.pds4+json", new Pds4ProductBusinessObject(true));
+    	formatters.put("application/vnd.nasa.pds.pds4+xml", new Pds4ProductBusinessObject(false));
     	formatters.put("application/xml", new PdsProductBusinessObject());
     	formatters.put("text/csv", new WyriwygBusinessObject());
     	formatters.put("text/html", new PdsProductBusinessObject());

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/JsonErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/JsonErrorMessageSerializer.java
@@ -14,11 +14,13 @@ import gov.nasa.pds.model.ErrorMessage;
 
 public class JsonErrorMessageSerializer extends AbstractHttpMessageConverter<ErrorMessage>
 {
-	public JsonErrorMessageSerializer()
-	{ super(MediaType.APPLICATION_JSON,
+	public JsonErrorMessageSerializer(){ 
+		super(MediaType.APPLICATION_JSON,
 			new MediaType("application","kvp+json"),
-			new MediaType("application", "pds4+json"),
-			MediaType.ALL); }
+			new MediaType("application", "vnd.nasa.pds.pds4+json"),
+			MediaType.ALL); 
+	}
+
 
 	@Override
 	protected boolean supports(Class<?> clazz) { return ErrorMessage.class.isAssignableFrom(clazz); }

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4JsonProductSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4JsonProductSerializer.java
@@ -33,7 +33,7 @@ public class Pds4JsonProductSerializer extends AbstractHttpMessageConverter<Pds4
      */
     public Pds4JsonProductSerializer()
     {
-        super(new MediaType("application", "pds4+json"));
+        super(new MediaType("application", "vnd.nasa.pds.pds4+json"));
     }
 
     

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4JsonProductsSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4JsonProductsSerializer.java
@@ -31,7 +31,7 @@ public class Pds4JsonProductsSerializer extends AbstractHttpMessageConverter<Pds
      */
     public Pds4JsonProductsSerializer()
     {
-        super(new MediaType("application", "pds4+json"));
+        super(new MediaType("application", "vnd.nasa.pds.pds4+json"));
     }
 
     

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4XmlProductSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4XmlProductSerializer.java
@@ -26,7 +26,7 @@ public class Pds4XmlProductSerializer extends AbstractHttpMessageConverter<Pds4P
 	static final public String NAMESPACE_URL = "http://pds.nasa.gov/api";
 
 	public Pds4XmlProductSerializer()
-	{ super(new MediaType("application", "pds4+xml")); }
+	{ super(new MediaType("application", "vnd.nasa.pds.pds4+xml")); }
 
 	@Override
 	protected boolean supports(Class<?> clazz)

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4XmlProductsSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4XmlProductsSerializer.java
@@ -31,7 +31,7 @@ public class Pds4XmlProductsSerializer  extends AbstractHttpMessageConverter<Pds
    	  private static final Logger log = LoggerFactory.getLogger(Pds4XmlProductsSerializer.class);	
 	
 	  public Pds4XmlProductsSerializer() {
-	      super(new MediaType("application", "pds4+xml"));
+	      super(new MediaType("application", "vnd.nasa.pds.pds4+xml"));
 	  }
 
 	  @Override

--- a/service/src/main/java/gov/nasa/pds/api/engineering/serializer/XmlErrorMessageSerializer.java
+++ b/service/src/main/java/gov/nasa/pds/api/engineering/serializer/XmlErrorMessageSerializer.java
@@ -15,7 +15,7 @@ import gov.nasa.pds.model.ErrorMessage;
 public class XmlErrorMessageSerializer extends AbstractHttpMessageConverter<ErrorMessage>
 {
 	public XmlErrorMessageSerializer()
-	{ super(MediaType.APPLICATION_XML, MediaType.TEXT_XML, new MediaType("application", "pds4+xml")); }
+	{ super(MediaType.APPLICATION_XML, MediaType.TEXT_XML, new MediaType("application", "vnd.nasa.pds.pds4+xml")); }
 
 	@Override
 	protected boolean supports(Class<?> clazz) { return ErrorMessage.class.isAssignableFrom(clazz); }


### PR DESCRIPTION
## 🗒️ Summary
Update the swagger YAML and all of the java code and swaggerhub 0.5.0-SNAPSHOT.
 
## ⚙️ Test Data and/or Report
By code review all pds4+ have been changed to vnd.nasa.pds.pds4+:

```
$ find service/ -name \*.java -exec grep 'pds4+' {} \; -print
    	formatters.put("application/vnd.nasa.pds.pds4+json", new Pds4ProductBusinessObject(true));
    	formatters.put("application/vnd.nasa.pds.pds4+xml", new Pds4ProductBusinessObject(false));
service/src/main/java/gov/nasa/pds/api/engineering/elasticsearch/business/RequestAndResponseContext.java
 * Custom serializer to write a Pds4Product in "pds4+json" format.
        super(new MediaType("application", "vnd.nasa.pds.pds4+json"));
service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4JsonProductSerializer.java
 * Custom serializer to write a Pds4Product in "pds4+json" format.
        super(new MediaType("application", "vnd.nasa.pds.pds4+json"));
service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4JsonProductsSerializer.java
	{ super(new MediaType("application", "vnd.nasa.pds.pds4+xml")); }
service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4XmlProductSerializer.java
	      super(new MediaType("application", "vnd.nasa.pds.pds4+xml"));
service/src/main/java/gov/nasa/pds/api/engineering/serializer/Pds4XmlProductsSerializer.java
	{ super(MediaType.APPLICATION_XML, MediaType.TEXT_XML, new MediaType("application", "vnd.nasa.pds.pds4+xml")); }
service/src/main/java/gov/nasa/pds/api/engineering/serializer/XmlErrorMessageSerializer.java
			new MediaType("application", "vnd.nasa.pds.pds4+json")); }
service/src/main/java/gov/nasa/pds/api/engineering/serializer/JsonErrorMessageSerializer.java
```

## ♻️ Related Issues
NASA-PDS/registry-api#464

