### PR TITLE
Skip ssl certificate verif

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -22,6 +22,7 @@ Follow instructions in README.txt in the decompressed folder
 
 ## Developers
 
+    
 ### Deployment
 
 Get a development release by cloning the current repository.

--- a/service/docker/Dockerfile.http
+++ b/service/docker/Dockerfile.http
@@ -15,34 +15,30 @@ RUN mkdir /usr/local/registry-api-service \
  && echo ${VERSION} > version.txt
 
 # Copy the data into the building container
-#COPY LICENSE.md /usr/local/registry-api-service
-#COPY NOTICE.txt /usr/local/registry-api-service
-#COPY README.md /usr/local/registry-api-service
+COPY LICENSE.md /usr/local/registry-api-service
+COPY NOTICE.txt /usr/local/registry-api-service
+COPY README.md /usr/local/registry-api-service
 
 # Resources shared with the rest of the world
-EXPOSE 8080
+EXPOSE 80
 
-WORKDIR /usr/local/registry-api-service
-
+# Use this if producing a Docker image from a release
 RUN set -ex \
+ && cd /usr/local/registry-api-service \
  && curl -L \
-         https://github.com/NASA-PDS/registry-api/releases/download/v${VERSION}/registry-api-service-${VERSION}-bin.tar.gz \
-         -o registry-api-service-bin.tar.gz \
- && tar xvf registry-api-service-bin.tar.gz \
- && mv registry-api-service-${VERSION}/* . \
- && mv registry-api-service-${VERSION}.jar registry-api-service.jar \
- && rm -fr registry-api-service-${VERSION} \
- && rm registry-api-service-bin.tar.gz
-
+         https://github.com/NASA-PDS/registry-api-service/releases/download/v${VERSION}/registry-api-service-${VERSION}.jar \
+         -o registry-api-service.jar \
+ && rm -rf /var/lib/apt/lists/*
 
 # TODO: Set-up bind dir for application.properties here...
 
+# Run the sevice by default
+WORKDIR /usr/local/registry-api-service
+
 # For release-based images 
 # TODO: the bind-dir needs to be added to the classpath as the first entry so the config file is assured to be picked up
-#CMD ["java", \
-#     # "-cp", "<bind_dir>", \
-#     "-cp", "/usr/local/registry-api-service/", \
-#     "-jar", "/usr/local/registry-api-service/registry-api-service.jar", \
-#     "gov.nasa.pds.api.registry.SpringBootMain"]
-ENTRYPOINT ["tail", "-f", "/dev/null"]
-
+CMD ["java", \
+     # "-cp", "<bind_dir>", \
+     "-cp", "/usr/local/registry-api-service", \
+     "-jar", "/usr/local/registry-api-service/registry-api-service.jar", \
+     "gov.nasa.pds.api.registry.SpringBootMain"]

--- a/service/docker/Dockerfile.http
+++ b/service/docker/Dockerfile.http
@@ -15,30 +15,34 @@ RUN mkdir /usr/local/registry-api-service \
  && echo ${VERSION} > version.txt
 
 # Copy the data into the building container
-COPY LICENSE.md /usr/local/registry-api-service
-COPY NOTICE.txt /usr/local/registry-api-service
-COPY README.md /usr/local/registry-api-service
+#COPY LICENSE.md /usr/local/registry-api-service
+#COPY NOTICE.txt /usr/local/registry-api-service
+#COPY README.md /usr/local/registry-api-service
 
 # Resources shared with the rest of the world
-EXPOSE 80
+EXPOSE 8080
 
-# Use this if producing a Docker image from a release
+WORKDIR /usr/local/registry-api-service
+
 RUN set -ex \
- && cd /usr/local/registry-api-service \
  && curl -L \
-         https://github.com/NASA-PDS/registry-api-service/releases/download/v${VERSION}/registry-api-service-${VERSION}.jar \
-         -o registry-api-service.jar \
- && rm -rf /var/lib/apt/lists/*
+         https://github.com/NASA-PDS/registry-api/releases/download/v${VERSION}/registry-api-service-${VERSION}-bin.tar.gz \
+         -o registry-api-service-bin.tar.gz \
+ && tar xvf registry-api-service-bin.tar.gz \
+ && mv registry-api-service-${VERSION}/* . \
+ && mv registry-api-service-${VERSION}.jar registry-api-service.jar \
+ && rm -fr registry-api-service-${VERSION} \
+ && rm registry-api-service-bin.tar.gz
+
 
 # TODO: Set-up bind dir for application.properties here...
 
-# Run the sevice by default
-WORKDIR /usr/local/registry-api-service
-
 # For release-based images 
 # TODO: the bind-dir needs to be added to the classpath as the first entry so the config file is assured to be picked up
-CMD ["java", \
-     # "-cp", "<bind_dir>", \
-     "-cp", "/usr/local/registry-api-service", \
-     "-jar", "/usr/local/registry-api-service/registry-api-service.jar", \
-     "gov.nasa.pds.api.registry.SpringBootMain"]
+#CMD ["java", \
+#     # "-cp", "<bind_dir>", \
+#     "-cp", "/usr/local/registry-api-service/", \
+#     "-jar", "/usr/local/registry-api-service/registry-api-service.jar", \
+#     "gov.nasa.pds.api.registry.SpringBootMain"]
+ENTRYPOINT ["tail", "-f", "/dev/null"]
+

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -228,26 +228,26 @@ POSSIBILITY OF SUCH DAMAGE.
 			<version>2.10.6</version>
 		</dependency>
 
-                <dependency>
-                  <groupId>com.sun.xml.bind</groupId>
-                  <artifactId>jaxb-core</artifactId>
-                  <version>2.3.0.1</version>
-                </dependency>
-                <dependency>
-                  <groupId>javax.xml.bind</groupId>
-                  <artifactId>jaxb-api</artifactId>
-                  <version>2.3.1</version>
-                </dependency>
-                <dependency>
-                  <groupId>com.sun.xml.bind</groupId>
-                  <artifactId>jaxb-impl</artifactId>
-                  <version>2.3.1</version>
-                </dependency>
-                <dependency>
-                  <groupId>org.javassist</groupId>
-                  <artifactId>javassist</artifactId>
-                  <version>3.25.0-GA</version>
-                </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-core</artifactId>
+          <version>2.3.0.1</version>
+        </dependency>
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+          <version>2.3.1</version>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+          <version>2.3.1</version>
+        </dependency>
+        <dependency>
+          <groupId>org.javassist</groupId>
+          <artifactId>javassist</artifactId>
+          <version>3.25.0-GA</version>
+        </dependency>
 	
 		<!-- https://mvnrepository.com/artifact/org.threeten/threetenbp -->
 		<dependency>
@@ -330,6 +330,13 @@ POSSIBILITY OF SUCH DAMAGE.
             <artifactId>aws-java-sdk-secretsmanager</artifactId>
             <version>1.11.1000</version>
         </dependency>
+        
+        <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
+		<dependency>
+		    <groupId>com.google.guava</groupId>
+		    <artifactId>guava</artifactId>
+		    <version>31.1-jre</version>
+		</dependency>
         
 	</dependencies>
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/opensearch/OpenSearchConfig.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/opensearch/OpenSearchConfig.java
@@ -144,6 +144,7 @@ public class OpenSearchConfig {
             }
 			
 			this.esRegistryConnection = new OpenSearchRegistryConnectionImpl(connectionBuilder);
+
 		}
 		return this.esRegistryConnection;
 	}

--- a/service/src/main/java/gov/nasa/pds/api/registry/opensearch/OpenSearchConfig.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/opensearch/OpenSearchConfig.java
@@ -12,6 +12,7 @@ import gov.nasa.pds.api.registry.SystemConstants;
 import gov.nasa.pds.api.registry.business.ProductBusinessObject;
 import gov.nasa.pds.api.registry.configuration.AWSSecretsAccess;
 import gov.nasa.pds.api.registry.search.RegistrySearchRequestBuilder;
+import gov.nasa.pds.api.registry.opensearch.OpenSearchRegistryConnectionImplBuilder;
 
 /* Keep this eventhough not directly referenced
  * 
@@ -29,7 +30,7 @@ public class OpenSearchConfig {
 	// This default for ES hosts is set in the constructor since we first want to check
 	// the environment if not set in the application properties. This preserves the
 	// original behavior when the default was specified in the Value annotation.
-	private static final String DEFAULT_ES_HOST = "localhost:9200";
+	
 	
 	@Value("#{'${openSearch.host:}'.split(',')}") 
 	private List<String> hosts;
@@ -43,17 +44,41 @@ public class OpenSearchConfig {
 	@Value("${openSearch.timeOutSeconds:60}")
 	private int timeOutSeconds;
 	
+	public int getTimeOutSeconds() {
+		return timeOutSeconds;
+	}
+
+	public void setTimeOutSeconds(int timeOutSeconds) {
+		this.timeOutSeconds = timeOutSeconds;
+	}
+
 	@Value("${openSearch.username:}")
 	private String username;
 	
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
 	@Value("${openSearch.password:}")
 	private String password;
 	
 	@Value("${openSearch.ssl:false}")
 	private boolean ssl;
     
-	@Value("${openSearch.sslCertificateVerification:true}")
-	private boolean sslCertificateVerification;
+	@Value("${openSearch.sslCertificateCNVerification:false}")
+	private boolean sslCertificateCNVerification;
 	
 	public List<String> getHosts() {
 		return hosts;
@@ -84,12 +109,12 @@ public class OpenSearchConfig {
 		return ssl;
 	}
 
-	public boolean doesSslCertificateVerification() {
-		return sslCertificateVerification;
+	public boolean doesSslCertificateVCNerification() {
+		return sslCertificateCNVerification;
 	}
 
-	public void setSslCertificateVerification(boolean sslCertificateVerification) {
-		this.sslCertificateVerification = sslCertificateVerification;
+	public void setSslCertificateCNVerification(boolean sslCertificateCNVerification) {
+		this.sslCertificateCNVerification = sslCertificateCNVerification;
 	}
 
 	public void setSsl(boolean ssl) {
@@ -102,10 +127,12 @@ public class OpenSearchConfig {
 	public OpenSearchRegistryConnection openSearchRegistryConnection() {
 		
 		if (esRegistryConnection == null) {
+			
+			OpenSearchRegistryConnectionImplBuilder connectionBuilder = new OpenSearchRegistryConnectionImplBuilder(this);
 
 			// see if ES user name is not set - if not, try to get from environment
 			if (this.username == null || "".equals(this.username)) {
-				this.trySetESCredsFromEnv();
+				connectionBuilder.trySetESCredsFromEnv();
 			}
 			
 			// do the same for ES hosts - the defaulting mechanism causes a rather elaborate
@@ -113,17 +140,10 @@ public class OpenSearchConfig {
 			log.debug(String.format("this.hosts : %s (%d)", this.hosts, this.hosts.size()));
             if (this.hosts == null || this.hosts.size() == 0 
              || this.hosts.get(0) == null || "".equals(this.hosts.get(0))) {
-            	setESHostsFromEnvOrDefault();
+            	connectionBuilder.setESHostsFromEnvOrDefault();
             }
 			
-			this.esRegistryConnection = new OpenSearchRegistryConnectionImpl(this.hosts,
-					this.registryIndex,
-					this.registryRefIndex,
-					this.timeOutSeconds,
-					this.username,
-					this.password,
-					this.ssl,
-					this.sslCertificateVerification);
+			this.esRegistryConnection = new OpenSearchRegistryConnectionImpl(connectionBuilder);
 		}
 		return this.esRegistryConnection;
 	}
@@ -147,41 +167,8 @@ public class OpenSearchConfig {
 	}
     
 
-	private void trySetESCredsFromEnv() {
 
-		String esCredsFromEnv = System.getenv(SystemConstants.ES_CREDENTIALS_ENV_VAR);
-
-		if (esCredsFromEnv != null && !"".equals(esCredsFromEnv)) {
-			log.info("Received ES login from environment");
-			DefaultKeyValue<String, String> esCreds = AWSSecretsAccess.parseSecret(esCredsFromEnv);
-			if (esCreds == null) {
-				String message = String.format("Value of %s environment variable is not in appropriate JSON format",
-				                               SystemConstants.ES_CREDENTIALS_ENV_VAR);
-				log.error(message);
-				throw new RuntimeException(message);
-			}
-
-			this.username = esCreds.getKey();
-			this.password = esCreds.getValue();
-			log.debug(String.format("ES Username from environment : [%s]", this.username));
-		}
-	}
 
 	
-	private void setESHostsFromEnvOrDefault() {
-
-		String esHosts = System.getenv(SystemConstants.ES_HOSTS_ENV_VAR);
-
-		if (esHosts != null && !"".equals(esHosts)) {
-			log.info("Received ES hosts from environment");
-		} else {
-			log.info(String.format("ES hosts not set in config or environment, defaulting to %s", DEFAULT_ES_HOST));
-			esHosts = DEFAULT_ES_HOST;
-		}
-		
-		log.debug(String.format("esHosts : %s", esHosts));
-			
-		this.hosts = List.of(esHosts.split(","));
-	}
 
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/opensearch/OpenSearchConfig.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/opensearch/OpenSearchConfig.java
@@ -52,6 +52,9 @@ public class OpenSearchConfig {
 	@Value("${openSearch.ssl:false}")
 	private boolean ssl;
     
+	@Value("${openSearch.sslCertificateVerification:true}")
+	private boolean sslCertificateVerification;
+	
 	public List<String> getHosts() {
 		return hosts;
 	}
@@ -79,6 +82,14 @@ public class OpenSearchConfig {
 		
 	public boolean isSsl() {
 		return ssl;
+	}
+
+	public boolean doesSslCertificateVerification() {
+		return sslCertificateVerification;
+	}
+
+	public void setSslCertificateVerification(boolean sslCertificateVerification) {
+		this.sslCertificateVerification = sslCertificateVerification;
 	}
 
 	public void setSsl(boolean ssl) {
@@ -111,7 +122,8 @@ public class OpenSearchConfig {
 					this.timeOutSeconds,
 					this.username,
 					this.password,
-					this.ssl);
+					this.ssl,
+					this.sslCertificateVerification);
 		}
 		return this.esRegistryConnection;
 	}

--- a/service/src/main/java/gov/nasa/pds/api/registry/opensearch/OpenSearchRegistryConnectionImpl.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/opensearch/OpenSearchRegistryConnectionImpl.java
@@ -12,6 +12,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
@@ -45,7 +46,7 @@ public class OpenSearchRegistryConnectionImpl implements OpenSearchRegistryConne
 	
 	public OpenSearchRegistryConnectionImpl()
 	{
-	    this(Arrays.asList("localhost:9200"), "registry", "registry-refs", 5, null, null, false);
+	    this(Arrays.asList("localhost:9200"), "registry", "registry-refs", 5, null, null, false, true);
 	}
 	
 	public OpenSearchRegistryConnectionImpl(List<String> hosts, 
@@ -54,7 +55,8 @@ public class OpenSearchRegistryConnectionImpl implements OpenSearchRegistryConne
 			int timeOutSeconds,
 			String username,
 			String password,
-			boolean ssl) {
+			boolean ssl,
+			boolean sslCertificateVerification) {
 		
 		List<HttpHost> httpHosts = new ArrayList<HttpHost>();
 		
@@ -95,6 +97,9 @@ public class OpenSearchRegistryConnectionImpl implements OpenSearchRegistryConne
 						        SSLContext sslContext = sslBld.build();
 	
 						        httpClientBuilder.setSSLContext(sslContext);
+						        if (!sslCertificateVerification) {
+						        	httpClientBuilder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+						        }
 			        		}
 				        	
 				            return httpClientBuilder

--- a/service/src/main/java/gov/nasa/pds/api/registry/opensearch/OpenSearchRegistryConnectionImpl.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/opensearch/OpenSearchRegistryConnectionImpl.java
@@ -31,6 +31,8 @@ import gov.nasa.pds.api.registry.opensearch.OpenSearchRegistryConnectionImplBuil
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Splitter;
+
 public class OpenSearchRegistryConnectionImpl implements OpenSearchRegistryConnection {
 	
     // key for getting the remotes from cross cluster config
@@ -50,16 +52,18 @@ public class OpenSearchRegistryConnectionImpl implements OpenSearchRegistryConne
 	    this(new OpenSearchRegistryConnectionImplBuilder());
 	}
 	
+	@SuppressWarnings("StringSplitter")
 	public OpenSearchRegistryConnectionImpl(OpenSearchRegistryConnectionImplBuilder connectionBuilder) {
 			
 		List<HttpHost> httpHosts = new ArrayList<HttpHost>();
 		
 		OpenSearchRegistryConnectionImpl.log.info("Connection to open search");
 		for (String host : connectionBuilder.getHosts()) {
-			String hostPort[] = host.split(":");
-			OpenSearchRegistryConnectionImpl.log.info("Host " + hostPort[0] + ":" + hostPort[1]);
-			httpHosts.add(new HttpHost(hostPort[0], 
-            		Integer.parseInt(hostPort[1]), 
+			
+			List<String> hostPort = Splitter.on(':').splitToList(host);
+			OpenSearchRegistryConnectionImpl.log.info("Host " + hostPort.get(0) + ":" + hostPort.get(1));
+			httpHosts.add(new HttpHost(hostPort.get(0), 
+            		Integer.parseInt(hostPort.get(1)), 
             		connectionBuilder.isSsl()?"https":"http"));
 	    	
 			}

--- a/service/src/main/java/gov/nasa/pds/api/registry/opensearch/OpenSearchRegistryConnectionImpl.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/opensearch/OpenSearchRegistryConnectionImpl.java
@@ -46,14 +46,12 @@ public class OpenSearchRegistryConnectionImpl implements OpenSearchRegistryConne
 	
 	
 	public OpenSearchRegistryConnectionImpl()
-	{
-		
+	{		
 	    this(new OpenSearchRegistryConnectionImplBuilder());
 	}
 	
 	public OpenSearchRegistryConnectionImpl(OpenSearchRegistryConnectionImplBuilder connectionBuilder) {
-	
-		
+			
 		List<HttpHost> httpHosts = new ArrayList<HttpHost>();
 		
 		OpenSearchRegistryConnectionImpl.log.info("Connection to open search");

--- a/service/src/main/java/gov/nasa/pds/api/registry/opensearch/OpenSearchRegistryConnectionImplBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/opensearch/OpenSearchRegistryConnectionImplBuilder.java
@@ -1,0 +1,151 @@
+package gov.nasa.pds.api.registry.opensearch;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.collections4.keyvalue.DefaultKeyValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import gov.nasa.pds.api.registry.SystemConstants;
+import gov.nasa.pds.api.registry.configuration.AWSSecretsAccess;
+import gov.nasa.pds.api.registry.opensearch.OpenSearchConfig;
+
+public class OpenSearchRegistryConnectionImplBuilder {
+
+	private static final String DEFAULT_ES_HOST = "localhost:9200";
+	
+	private static final Logger log = LoggerFactory.getLogger(OpenSearchRegistryConnectionImplBuilder.class);
+
+	private List<String> hosts;
+	public List<String> getHosts() {
+		return hosts;
+	}
+
+
+	public void setHosts(List<String> hosts) {
+		this.hosts = hosts;
+	}
+
+
+	public String getUsername() {
+		return username;
+	}
+
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+
+	public String getPassword() {
+		return password;
+	}
+
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+
+	public String getRegistryIndex() {
+		return registryIndex;
+	}
+
+
+	public String getRegistryRefIndex() {
+		return registryRefIndex;
+	}
+
+
+	public int getTimeOutSeconds() {
+		return timeOutSeconds;
+	}
+
+
+	public boolean isSsl() {
+		return ssl;
+	}
+
+
+	public boolean isSslCertificateCNVerification() {
+		return sslCertificateCNVerification;
+	}
+
+	private final String registryIndex;
+	private final String registryRefIndex;
+	private final int timeOutSeconds;
+	private final boolean ssl;
+	private final boolean sslCertificateCNVerification;
+
+	private String username;
+	private String password;
+	
+	
+	public OpenSearchRegistryConnectionImplBuilder() {
+		// Default builder
+		this.hosts = Arrays.asList("localhost:9200");
+		this.registryIndex = "registry";
+		this.registryRefIndex = "registry-refs";
+		this.timeOutSeconds = 5;
+		this.username = null;
+		this.password = null;
+		this.ssl = false;
+		this.sslCertificateCNVerification = true;
+
+	}
+
+	public OpenSearchRegistryConnectionImplBuilder(OpenSearchConfig openSearchConfig) {
+		
+
+		
+		this.hosts = openSearchConfig.getHosts();
+		this.registryIndex = openSearchConfig.getRegistryIndex();
+		this.registryRefIndex = openSearchConfig.getRegistryRefIndex();
+		this.timeOutSeconds = openSearchConfig.getTimeOutSeconds();
+		this.ssl = openSearchConfig.isSsl();
+		this.sslCertificateCNVerification = openSearchConfig.doesSslCertificateVCNerification();
+		this.username = openSearchConfig.getUsername();
+		this.password = openSearchConfig.getPassword();
+		
+		
+	}
+	
+	
+	public void trySetESCredsFromEnv() {
+
+		String esCredsFromEnv = System.getenv(SystemConstants.ES_CREDENTIALS_ENV_VAR);
+
+		if (esCredsFromEnv != null && !"".equals(esCredsFromEnv)) {
+			log.info("Received ES login from environment");
+			DefaultKeyValue<String, String> esCreds = AWSSecretsAccess.parseSecret(esCredsFromEnv);
+			if (esCreds == null) {
+				String message = String.format("Value of %s environment variable is not in appropriate JSON format",
+				                               SystemConstants.ES_CREDENTIALS_ENV_VAR);
+				log.error(message);
+				throw new RuntimeException(message);
+			}
+
+			this.username = esCreds.getKey();
+			this.password = esCreds.getValue();
+			log.debug(String.format("ES Username from environment : [%s]", this.username));
+		}
+	}
+	
+	public void setESHostsFromEnvOrDefault() {
+
+		String esHosts = System.getenv(SystemConstants.ES_HOSTS_ENV_VAR);
+
+		if (esHosts != null && !"".equals(esHosts)) {
+			log.info("Received ES hosts from environment");
+		} else {
+			log.info(String.format("ES hosts not set in config or environment, defaulting to %s", DEFAULT_ES_HOST));
+			esHosts = DEFAULT_ES_HOST;
+		}
+		
+		log.debug(String.format("esHosts : %s", esHosts));
+			
+		this.hosts = List.of(esHosts.split(","));
+	}
+
+}

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 springfox.documentation.swagger.v2.path=/api-docs
 server.contextPath=/
-server.port=8081
+server.port=8080
 server.use-forward-headers=true
 
 #spring.jackson.date-format=io.swagger.RFC3339DateFormat
@@ -21,11 +21,11 @@ openSearch.host=localhost:9200
 openSearch.registryIndex=registry
 openSearch.registryRefIndex=registry-refs
 openSearch.timeOutSeconds=60
-openSearch.username=admin
-openSearch.password=admin
-openSearch.ssl=true
+openSearch.username=
+openSearch.password=
+openSearch.ssl=false
 # use only for development purpose, left it to true otherwise
-openSearch.sslCertificateCNVerification=false
+openSearch.sslCertificateCNVerification=true
 
 # Only show products with following archive statuses
 filter.archiveStatus=archived,certified

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -25,7 +25,7 @@ openSearch.username=admin
 openSearch.password=admin
 openSearch.ssl=true
 # use only for development purpose, left it to true otherwise
-openSearch.sslCertificateVerification=false
+openSearch.sslCertificateCNVerification=false
 
 # Only show products with following archive statuses
 filter.archiveStatus=archived,certified

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 springfox.documentation.swagger.v2.path=/api-docs
 server.contextPath=/
-server.port=8080
+server.port=8081
 server.use-forward-headers=true
 
 #spring.jackson.date-format=io.swagger.RFC3339DateFormat
@@ -21,9 +21,11 @@ openSearch.host=localhost:9200
 openSearch.registryIndex=registry
 openSearch.registryRefIndex=registry-refs
 openSearch.timeOutSeconds=60
-openSearch.username=
-openSearch.password=
-openSearch.ssl=false
+openSearch.username=admin
+openSearch.password=admin
+openSearch.ssl=true
+# use only for development purpose, left it to true otherwise
+openSearch.sslCertificateVerification=false
 
 # Only show products with following archive statuses
 filter.archiveStatus=archived,certified


### PR DESCRIPTION
## 🗒️ Summary
- add an option to skip SSL certificate verification when connecting to opensearch. This is useful when as a developer/tester we use the docker compose deployment which starts opensearch with ssl certificates which are only valid when requesting opensearch from the internal docker network (as elasticsearch:9200), which is not the case when one develop in an Eclipse IDE deployed on the host (e.g. developer's laptop).
- bump the version to 1.0.0-SNAPSHOT to get ready for v1
- 
## ⚙️ Test Data and/or Report
One of the following should be included here:
* Reference to regression test included in code (preferred wherever reasonable)
* Attach test data here + outputs of tests

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


