### PR TITLE
registry-api #115 : Update download repo to registry-api

### DIFF
--- a/service/docker/Dockerfile.http
+++ b/service/docker/Dockerfile.http
@@ -26,19 +26,15 @@ EXPOSE 80
 RUN set -ex \
  && cd /usr/local/registry-api-service \
  && curl -L \
-         https://github.com/NASA-PDS/registry-api-service/releases/download/v${VERSION}/registry-api-service-${VERSION}.jar \
+         https://github.com/NASA-PDS/registry-api/releases/download/v${VERSION}/registry-api-service-${VERSION}.jar \
          -o registry-api-service.jar \
  && rm -rf /var/lib/apt/lists/*
-
-# TODO: Set-up bind dir for application.properties here...
 
 # Run the sevice by default
 WORKDIR /usr/local/registry-api-service
 
 # For release-based images 
-# TODO: the bind-dir needs to be added to the classpath as the first entry so the config file is assured to be picked up
 CMD ["java", \
-     # "-cp", "<bind_dir>", \
      "-cp", "/usr/local/registry-api-service", \
      "-jar", "/usr/local/registry-api-service/registry-api-service.jar", \
      "gov.nasa.pds.api.registry.SpringBootMain"]

--- a/service/docker/Dockerfile.http
+++ b/service/docker/Dockerfile.http
@@ -1,8 +1,11 @@
 FROM openjdk:11-slim
 
 # Get arguments from the build command line
-ARG version
+ARG version \
+    jar_version=$version
+
 ENV VERSION=$version
+ENV JAR_VERSION=$jar_version
 
 # Build up the OS
 RUN apt-get update \
@@ -12,7 +15,7 @@ RUN apt-get update \
 # Make room for the app and capture the version
 RUN mkdir /usr/local/registry-api-service \
  && cd /usr/local/registry-api-service \
- && echo ${VERSION} > version.txt
+ && echo "Release version : " ${VERSION} " / Jar version : " ${JAR_VERSION}  > version.txt
 
 # Copy the data into the building container
 COPY LICENSE.md /usr/local/registry-api-service
@@ -26,7 +29,7 @@ EXPOSE 80
 RUN set -ex \
  && cd /usr/local/registry-api-service \
  && curl -L \
-         https://github.com/NASA-PDS/registry-api/releases/download/v${VERSION}/registry-api-service-${VERSION}.jar \
+         https://github.com/NASA-PDS/registry-api/releases/download/v${VERSION}/registry-api-service-${JAR_VERSION}.jar \
          -o registry-api-service.jar \
  && rm -rf /var/lib/apt/lists/*
 

--- a/service/docker/Dockerfile.https
+++ b/service/docker/Dockerfile.https
@@ -3,9 +3,11 @@ FROM openjdk:11-slim
 # Get arguments from the build command line
 ARG version \
     keystore_pass \
-    key_pass
+    key_pass \
+    jar_version=$version
 
 ENV VERSION=$version
+ENV JAR_VERSION=$jar_version
 
 # Build up the OS
 RUN apt-get update && \
@@ -15,7 +17,7 @@ RUN apt-get update && \
 # Make room for the app and capture the version
 RUN mkdir /usr/local/registry-api-service \
  && cd /usr/local/registry-api-service \
- && echo ${VERSION} > version.txt
+ && echo "Release version : " ${VERSION} " / Jar version : " ${JAR_VERSION}  > version.txt
 
 # Copy the data into the building container
 COPY LICENSE.md /usr/local/registry-api-service
@@ -29,7 +31,7 @@ EXPOSE 443
 RUN set -ex \
  && cd /usr/local/registry-api-service \
  && curl -L \
-         https://github.com/NASA-PDS/registry-api/releases/download/v${VERSION}/registry-api-service-${VERSION}.jar \
+         https://github.com/NASA-PDS/registry-api/releases/download/v${VERSION}/registry-api-service-${JAR_VERSION}.jar \
          -o registry-api-service.jar
 
 # Now generate/store the self signed cert.

--- a/service/docker/Dockerfile.https
+++ b/service/docker/Dockerfile.https
@@ -29,10 +29,8 @@ EXPOSE 443
 RUN set -ex \
  && cd /usr/local/registry-api-service \
  && curl -L \
-         https://github.com/NASA-PDS/registry-api-service/releases/download/v${VERSION}/registry-api-service-${VERSION}.jar \
+         https://github.com/NASA-PDS/registry-api/releases/download/v${VERSION}/registry-api-service-${VERSION}.jar \
          -o registry-api-service.jar
-
-# TODO: Set-up bind dir for application.properties here...
 
 # Now generate/store the self signed cert.
 RUN cd /usr/local/registry-api-service \
@@ -43,9 +41,7 @@ RUN cd /usr/local/registry-api-service \
 # Run the sevice by default
 WORKDIR /usr/local/registry-api-service
 
-# TODO: the bind-dir needs to be added to the classpath as the first entry so the config file is assured to be picked up
 CMD ["java", \
-     # "-cp", "<bind_dir>", \
      "-cp", "/usr/local/registry-api-service", \
      "-jar", "/usr/local/registry-api-service/registry-api-service.jar", \
      "gov.nasa.pds.api.registry.SpringBootMain"]


### PR DESCRIPTION
After the repository re-organization, the repository for downloading releases has changed from registry-api-service to registry-api. Dockerfile.http and Dockerfile.https for the registry service have been updated.