### PR TITLE
Fixes #141

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -112,27 +112,22 @@
     <!--SpringFox dependencies -->
     <dependency>
       <groupId>io.springfox</groupId>
-      <artifactId>springfox-swagger2</artifactId>
-      <version>${springfox-version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.springfox</groupId>
-      <artifactId>springfox-swagger-ui</artifactId>
-      <version>${springfox-version}</version>
-    </dependency>
-    
+      <artifactId>springfox-boot-starter</artifactId>
+      <version>3.0.0</version>
+    </dependency>    
+
     <!-- https://mvnrepository.com/artifact/org.springframework/spring-web -->
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>5.3.19</version>
+      <version>5.3.20</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.springframework/spring-context -->
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>5.3.19</version>
+      <version>5.3.20</version>
     </dependency>
 
     

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -120,16 +120,11 @@ POSSIBILITY OF SUCH DAMAGE.
 	<dependencies>
 
 		<!--SpringFox dependencies -->
-		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger2</artifactId>
-			<version>${springfox-version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger-ui</artifactId>
-			<version>${springfox-version}</version>
-		</dependency>
+                <dependency>
+                  <groupId>io.springfox</groupId>
+                  <artifactId>springfox-boot-starter</artifactId>
+                  <version>3.0.0</version>
+                </dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.springframework/spring-web -->
 		<dependency>
@@ -345,7 +340,7 @@ POSSIBILITY OF SUCH DAMAGE.
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-dependencies</artifactId>
-            <version>2.6.6</version>
+            <version>2.7.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/service/src/main/java/gov/nasa/pds/api/registry/configuration/ApiDocumentation.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/configuration/ApiDocumentation.java
@@ -22,7 +22,7 @@ public class ApiDocumentation {
 
     	String contextPath = this.contextPath.endsWith("/")?this.contextPath:this.contextPath+"/";
 
-        System.out.println(contextPath+"swagger-ui.html");
-        return "redirect:"+contextPath+"swagger-ui.html";
+        System.out.println(contextPath+"swagger-ui/index.html");
+        return "redirect:"+contextPath+"swagger-ui/index.html";
     }
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/configuration/WebMVCConfig.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/configuration/WebMVCConfig.java
@@ -42,9 +42,6 @@ public class WebMVCConfig implements WebMvcConfigurer
 	@Override
     public void addResourceHandlers(ResourceHandlerRegistry registry)
 	{
-		registry.addResourceHandler("swagger-ui.html")
-		.addResourceLocations("classpath:/META-INF/resources/");
-
 		registry.addResourceHandler("/webjars/**")
 		.addResourceLocations("classpath:/META-INF/resources/webjars/");
     }


### PR DESCRIPTION
## 🗒️ Summary
It seems it is the swagger2 and springfox interaction that required a slightly different build to get the API documentation back. It has moved so updated 

## ⚙️ Test Data and/or Report
- start registry-api service
- point browser at localhost:8080 (should redirect to /swagger-ui/index.html

![api-doc](https://user-images.githubusercontent.com/1130658/173206295-91d86b34-3814-4713-9701-f5a48c84e8e6.png)


## ♻️ Related Issues
#141 on release 1.0.1 branch


