### PR TITLE
Add a Dockerfile for building images for AWS deployments

### DIFF
--- a/service/docker/Dockerfile
+++ b/service/docker/Dockerfile
@@ -79,7 +79,7 @@ WORKDIR /usr/local/registry-api-service
 EXPOSE  80
 CMD     [ \
     "java", \
-    "-jar", "/usr/local/registry-api-service/registry-api-service.jar", ] \
+    "-jar", "/usr/local/registry-api-service/registry-api-service.jar", \
     "gov.nasa.pds.api.registry.SpringBootMain" \
 ]
 

--- a/service/docker/Dockerfile.aws
+++ b/service/docker/Dockerfile.aws
@@ -1,0 +1,100 @@
+# Copyright © 2022, California Institute of Technology ("Caltech").
+# U.S. Government sponsorship acknowledged.
+# 
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# • Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# • Redistributions must reproduce the above copyright notice, this list of
+#   conditions and the following disclaimer in the documentation and/or other
+#   materials provided with the distribution.
+# • Neither the name of Caltech nor its operating division, the Jet Propulsion
+#   Laboratory, nor the names of its contributors may be used to endorse or
+#   promote products derived from this software without specific prior written
+#   permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Dockerfile for the Registry API
+# ===============================
+#
+# Depending on the build arguments, you could get a Dockerfile using local
+# assets or one with built and released assets.
+#
+#
+# Basis
+# -----
+#
+# Normally we'd prefer Alpine Linux, but JDK 11 isn't available with it, so
+# we go with a slim Debian. Debian's good too.
+
+FROM openjdk:11-slim
+
+
+# API JAR file
+# ------------
+#
+# Provide a `--build-arg` to tell the image builder where the Registry API
+# `.jar` file may found. This can be a file on the filesystem (sent as part
+# of the build context) or a URL to a remote file.
+
+ARG api_jar
+
+
+# Layering
+# --------
+#
+# Add the API JAR file and the libtcnative-1 package—which is needed for
+# some reason.
+
+ADD $api_jar /usr/local/registry-api-service/registry-api-service.jar
+
+RUN : &&\
+    apt-get update --quiet --yes &&\
+    apt-get install --quiet --yes libtcnative-1 &&\
+    apt-get autoclean --quiet --yes &&\
+    rm --recursive --force /var/lib/apt/lists/* &&\
+    :
+
+# Copy in the AWS-specific application properties file. The contents of this file dictates that certain runtime
+# values are obtained in th manner appropriate to AWS (e.g. the Opensearch login is obtained from an environment
+# variable that has been set via the Secrets Manager.).
+COPY src/main/resources/application.properties.aws /usr/local/registry-api-service/application.properties
+
+
+# Image Morphology
+# ----------------
+#
+# External context.
+
+WORKDIR /usr/local/registry-api-service
+EXPOSE  80
+CMD     [ \
+    "java", \
+    "-jar", "/usr/local/registry-api-service/registry-api-service.jar", ] \
+    "gov.nasa.pds.api.registry.SpringBootMain" \
+]
+
+
+# Labels
+# ------
+#
+# `org.label-schema` is deprecated, but no one can figure out whatever
+# replaced it, so we'll use it here.
+
+LABEL "org.label-schema.name" = "PDS Registry API"
+LABEL "org.label-schema.description" = "Planetary Data System's Application Programmer's Interface for the Registry"
+LABEL "org.label-schema.url" = "https://github.com/NASA-PDS/registry-api"

--- a/service/docker/Dockerfile.aws
+++ b/service/docker/Dockerfile.aws
@@ -84,7 +84,7 @@ WORKDIR /usr/local/registry-api-service
 EXPOSE  80
 CMD     [ \
     "java", \
-    "-jar", "/usr/local/registry-api-service/registry-api-service.jar", ] \
+    "-jar", "/usr/local/registry-api-service/registry-api-service.jar", \
     "gov.nasa.pds.api.registry.SpringBootMain" \
 ]
 

--- a/service/docker/README.md
+++ b/service/docker/README.md
@@ -28,6 +28,10 @@ Building an image from a released jar file:
 $ docker image build --build-arg api_jar=https://github.com/NASA-PDS/registry-api/releases/download/v1.0.0/registry-api-service-1.0.0.jar --tag nasapds/registry-api-service:1.0.0 --file service/docker/Dockerfile .
 ```
 
+## 📍 Dockerfile.aws
+
+This Dockerfile is used to make images for AWS deployments of the registry manager. It copies in an AWS-specific application.properties file which has been setup to inform the service to obtain certain properties as environment variable values that have been injected by the Elastic Container Service (ECS) runtime. An example of this is the Opensearch credentials from the Secrets Manager.
+
 ## 📍 Dockerfile.local
 
 You can ignore `Dockerfile.local` unless you're @al-niessner.


### PR DESCRIPTION
## 🗒️ Summary
Creation of AWS-specific Dockerfile, update README to indicate its purpose.

AWS deployments needs a specific application.properties which leaves certain properties empty, indicating to the service to obtain their values from environment variables that have been injected into the container by the Elastic Container Service (ECS) runtime.

An example of this is the Opensearch login which is provided by the Secrets Manager.

## ♻️ Related Issues
[registry-api 117](https://github.com/NASA-PDS/registry-api/issues/117)
[registry-api 140](https://github.com/NASA-PDS/registry-api/issues/140)
