### PR TITLE
add curl in docker image so to wait for opensearch to be ready

### DIFF
--- a/model/swagger.yml
+++ b/model/swagger.yml
@@ -3,7 +3,7 @@ info:
   description: |
     Registry API enabling advanced search on PDS data and metadata. The API provides end-points to search for bundles, collections and any PDS products with advanced search queries. It also enables to browse the archive hierarchically downward (e.g. collection/s products) or upward (e.g. bundles containing a product).
     The detailed syntax for querying the end-point is given in the reference documentation.
-  version: refactored
+  version: 1.1.0-SNAPSHOT
   title: Registry API
   termsOfService: 'http://pds.nasa.gov'
   contact:

--- a/service/docker/Dockerfile
+++ b/service/docker/Dockerfile
@@ -65,6 +65,7 @@ ADD $api_jar /usr/local/registry-api-service/registry-api-service.jar
 RUN : &&\
     apt-get update --quiet --yes &&\
     apt-get install --quiet --yes libtcnative-1 &&\
+    apt-get install curl -y &&\
     apt-get autoclean --quiet --yes &&\
     rm --recursive --force /var/lib/apt/lists/* &&\
     :


### PR DESCRIPTION
## 🗒️ Summary
Add curl in the docker image

## ⚙️ Test Data and/or Report
Generate the docker image locally:
    docker image build --build-arg api_jar=https://github.com/NASA-PDS/registry-api/releases/download/v1.0.1/registry-api-service-1.0.1.jar --tag nasapds/registry-api-service .

Launch the registry integrated:

    git clone https://github.com/NASA-PDS/registry.git
    cd registry/docker
    docker compose --profile=int-registry-service-loader up

The registry should start and api available on localhost:8080/


## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Fixes https://github.com/NASA-PDS/registry/issues/69

