### PR TITLE
changed string searching

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/model/Antlr4SearchListener.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/Antlr4SearchListener.java
@@ -13,9 +13,9 @@ import java.util.List;
 
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.opensearch.index.query.BoolQueryBuilder;
-import org.opensearch.index.query.MatchQueryBuilder;
-import org.opensearch.index.query.WildcardQueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.SimpleQueryStringBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 
 public class Antlr4SearchListener extends SearchBaseListener
@@ -50,7 +50,7 @@ public class Antlr4SearchListener extends SearchBaseListener
 	 {
 		 for (QueryBuilder qb : musts) this.query.must(qb);
 		 for (QueryBuilder qb : nots) this.query.mustNot(qb);
-		 for (QueryBuilder qb : shoulds) this.query.should(qb);
+		 for (QueryBuilder qb : shoulds) this.query.filter(qb);
 	 }
 	 
 	 @Override
@@ -88,7 +88,7 @@ public class Antlr4SearchListener extends SearchBaseListener
 
 		 for (QueryBuilder qb : musts) group.must(qb);
 		 for (QueryBuilder qb : nots) group.mustNot(qb);
-		 for (QueryBuilder qb : shoulds) group.should(qb);
+		 for (QueryBuilder qb : shoulds) group.filter(qb);
 
 		 if (0 < depth)
 		 {
@@ -147,7 +147,7 @@ public class Antlr4SearchListener extends SearchBaseListener
 
         if (this.operator == operation.eq || this.operator == operation.ne)
         {
-            comparator = new MatchQueryBuilder(left, right);
+            comparator = new TermQueryBuilder(left, right);
         }
         else
         {
@@ -196,8 +196,7 @@ public class Antlr4SearchListener extends SearchBaseListener
         
         String right = ctx.STRINGVAL().getText();
         right = right.substring(1, right.length() - 1);
-        
-        QueryBuilder comparator = new WildcardQueryBuilder(left, right);
+        QueryBuilder comparator = new SimpleQueryStringBuilder(right).field(left).fuzzyMaxExpansions(0);
 
         if("not".equalsIgnoreCase(ctx.getChild(1).getText()))
         {

--- a/service/src/main/resources/application.properties.all
+++ b/service/src/main/resources/application.properties.all
@@ -21,11 +21,11 @@ openSearch.host=es:9200
 openSearch.registryIndex=registry
 openSearch.registryRefIndex=registry-refs
 openSearch.timeOutSeconds=60
-openSearch.username=
-openSearch.password=
-openSearch.ssl=false
+openSearch.username=admin
+openSearch.password=admin
+openSearch.ssl=true
 # use only for development purpose, left it to true otherwise
-openSearch.sslCertificateCNVerification=true
+openSearch.sslCertificateCNVerification=false
 
 # Only show products with following archive statuses
 filter.archiveStatus=archived,certified,staged

--- a/service/src/test/java/gov/nasa/pds/api/registry/opensearch/Antlr4SearchListenerTest.java
+++ b/service/src/test/java/gov/nasa/pds/api/registry/opensearch/Antlr4SearchListenerTest.java
@@ -8,9 +8,9 @@ import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.opensearch.index.query.BoolQueryBuilder;
-import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;
-import org.opensearch.index.query.WildcardQueryBuilder;
+import org.opensearch.index.query.SimpleQueryStringBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -62,9 +62,9 @@ public class Antlr4SearchListenerTest
 		Assertions.assertEquals (query.must().size(), 1);
 		Assertions.assertEquals (query.mustNot().size(), 0);
 		Assertions.assertEquals (query.should().size(), 0);
-		Assertions.assertTrue (query.must().get(0) instanceof WildcardQueryBuilder);
-		Assertions.assertEquals (((WildcardQueryBuilder)query.must().get(0)).fieldName(), "lid");
-		Assertions.assertEquals (((WildcardQueryBuilder)query.must().get(0)).value(), "*pdart14_meap");
+		Assertions.assertTrue (query.must().get(0) instanceof SimpleQueryStringBuilder);
+		Assertions.assertTrue (((SimpleQueryStringBuilder)query.must().get(0)).fields().containsKey("lid"));
+		Assertions.assertEquals (((SimpleQueryStringBuilder)query.must().get(0)).value(), "*pdart14_meap");
 	}
 
 	
@@ -77,9 +77,9 @@ public class Antlr4SearchListenerTest
         Assertions.assertEquals(query.must().size(), 0);
         Assertions.assertEquals(query.mustNot().size(), 1);
         Assertions.assertEquals(query.should().size(), 0);
-        Assertions.assertTrue(query.mustNot().get(0) instanceof WildcardQueryBuilder);
-        Assertions.assertEquals(((WildcardQueryBuilder) query.mustNot().get(0)).fieldName(), "lid");
-        Assertions.assertEquals(((WildcardQueryBuilder) query.mustNot().get(0)).value(), "pdart14_meap?");
+        Assertions.assertTrue(query.mustNot().get(0) instanceof SimpleQueryStringBuilder);
+        Assertions.assertTrue(((SimpleQueryStringBuilder) query.mustNot().get(0)).fields().containsKey("lid"));
+        Assertions.assertEquals(((SimpleQueryStringBuilder) query.mustNot().get(0)).value(), "pdart14_meap?");
     }
 
     
@@ -92,9 +92,9 @@ public class Antlr4SearchListenerTest
 		Assertions.assertEquals (query.must().size(), 1);
 		Assertions.assertEquals (query.mustNot().size(), 0);
 		Assertions.assertEquals (query.should().size(), 0);
-		Assertions.assertTrue (query.must().get(0) instanceof MatchQueryBuilder);
-		Assertions.assertEquals (((MatchQueryBuilder)query.must().get(0)).fieldName(), "lid");
-		Assertions.assertEquals (((MatchQueryBuilder)query.must().get(0)).value(), "*pdart14_meap?");
+		Assertions.assertTrue (query.must().get(0) instanceof TermQueryBuilder);
+		Assertions.assertEquals (((TermQueryBuilder)query.must().get(0)).fieldName(), "lid");
+		Assertions.assertEquals (((TermQueryBuilder)query.must().get(0)).value(), "*pdart14_meap?");
 	}
 
 
@@ -180,12 +180,12 @@ public class Antlr4SearchListenerTest
 
 		Assertions.assertEquals (query.must().size(), 0);
 		Assertions.assertEquals (query.mustNot().size(), 0);
-		Assertions.assertEquals (query.should().size(), 2);
-		Assertions.assertTrue (query.should().get(0) instanceof BoolQueryBuilder);
-		nest = (BoolQueryBuilder)query.should().get(0);
+		Assertions.assertEquals (query.filter().size(), 2);
+		Assertions.assertTrue (query.filter().get(0) instanceof BoolQueryBuilder);
+		nest = (BoolQueryBuilder)query.filter().get(0);
 		Assertions.assertEquals (nest.must().size(), 2);
 		Assertions.assertEquals (nest.mustNot().size(), 0);
-		Assertions.assertEquals (nest.should().size(), 0);
+		Assertions.assertEquals (nest.filter().size(), 0);
 		Assertions.assertTrue (nest.must().get(0) instanceof RangeQueryBuilder);
 		Assertions.assertTrue (nest.must().get(1) instanceof RangeQueryBuilder);
 		Assertions.assertEquals (((RangeQueryBuilder)nest.must().get(0)).fieldName(), "timestamp");
@@ -198,10 +198,10 @@ public class Antlr4SearchListenerTest
 		Assertions.assertEquals (((RangeQueryBuilder)nest.must().get(1)).to(), "27");
 		Assertions.assertTrue (((RangeQueryBuilder)nest.must().get(1)).includeLower());
 		Assertions.assertTrue (((RangeQueryBuilder)nest.must().get(1)).includeUpper());
-		nest = (BoolQueryBuilder)query.should().get(1);
+		nest = (BoolQueryBuilder)query.filter().get(1);
 		Assertions.assertEquals (nest.must().size(), 2);
 		Assertions.assertEquals (nest.mustNot().size(), 0);
-		Assertions.assertEquals (nest.should().size(), 0);
+		Assertions.assertEquals (nest.filter().size(), 0);
 		Assertions.assertTrue (nest.must().get(0) instanceof RangeQueryBuilder);
 		Assertions.assertTrue (nest.must().get(1) instanceof RangeQueryBuilder);
 		Assertions.assertEquals (((RangeQueryBuilder)nest.must().get(0)).fieldName(), "timestamp");
@@ -226,9 +226,9 @@ public class Antlr4SearchListenerTest
 		Assertions.assertEquals (query.must().size(), 1);
 		Assertions.assertEquals (query.mustNot().size(), 0);
 		Assertions.assertEquals (query.should().size(), 0);
-		Assertions.assertTrue (query.must().get(0) instanceof MatchQueryBuilder);
-		Assertions.assertEquals (((MatchQueryBuilder)query.must().get(0)).fieldName(), "ref_lid_target");
-		Assertions.assertEquals (((MatchQueryBuilder)query.must().get(0)).value(), "urn:nasa:pds:context:target:planet.mercury");
+		Assertions.assertTrue (query.must().get(0) instanceof TermQueryBuilder);
+		Assertions.assertEquals (((TermQueryBuilder)query.must().get(0)).fieldName(), "ref_lid_target");
+		Assertions.assertEquals (((TermQueryBuilder)query.must().get(0)).value(), "urn:nasa:pds:context:target:planet.mercury");
 	}
 	
 	@Test


### PR DESCRIPTION
## 🗒️ Summary

Re-enabled the unit testing for the queries that use the local language.

Seems that wildcards is not well implemented in the later elasticsearch and opensearch implementations. The most recent documentation for either has changed significantly that if searhing for strings, then they offer a short globish like set of patterns. Moved from using wildcards to this new string and it seems to be working.

The eq operator had some problems because it was using should instead of filter for the or condition. SHould returns everything with a score value to represent the closes match from the furthest. Changed over to filter and the or condition is now behaving as expected.

## ⚙️ Test Data and/or Report

Unittests pass:

```
$ curl --location --request GET 'http://localhost:8080/gid/any?limit=10&fields=title&q=title%20like%20%22Insight%2BRAD%22' --header 'Accept: text/csv'
title
"InSight RAD Calibrated Data Collection"
"InSight RAD Derived Data Collection"
"InSight RAD Raw Data Collection"
```

```
$ curl --location --request GET 'http://localhost:8080/gid/any?limit=10&fields=title&q=title%20eq%20%22InSight%20RAD%2A%22' --header 'Accept: text/csv'

$
```

## ♻️ Related Issues
#134 
#144 



