### PR TITLE
registry-api-164 : enhance Cloudfront function to be more robust

### DIFF
--- a/service/terraform/aws/api_uri_rewrite.js
+++ b/service/terraform/aws/api_uri_rewrite.js
@@ -11,14 +11,14 @@ function handler(event) {
     var request = event.request;
     var incomingUri = request.uri;
 
-    // split the uri
-    var uriParts = incomingUri.split("/");
+    // continue with the rewrite only if "/api/search*" is first in the URI
+    if (incomingUri.startsWith("/api/search")) {
 
-    // continue with the rewrite only if "/api/search" is first in the URI
-    if (uriParts[1].toLowerCase() == "api" && uriParts[2].toLowerCase() == "search" ) {
+        // split the uri
+        var uriParts = incomingUri.split("/");
 
-        // at a minimum service and version are required, otherwise fall through w/o changes
-        if (uriParts.length >= 4) {
+        // at a minimum service, version and command are required, otherwise fall through w/o changes
+        if (uriParts.length > 4 && uriParts[4].trim() != "") {
             // extract service and version which are placed in the HTTP header
             var resultHeader = uriParts[2] + "/" + uriParts[3];
 
@@ -33,7 +33,6 @@ function handler(event) {
             request.uri = newUri;
             request.headers['x-request-node'] = { "value" : resultHeader };
         }
-
     }
 
     return request;

--- a/service/terraform/ecs.tf
+++ b/service/terraform/ecs.tf
@@ -127,7 +127,7 @@ resource "aws_lb_target_group" "pds-registry-target-group" {
 
   health_check {
     enabled = true
-    path    = "/"
+    path    = "/swagger-ui.html"
     matcher = "200,301,302"
     interval = 60
   }

--- a/service/terraform/variables.tf
+++ b/service/terraform/variables.tf
@@ -70,7 +70,7 @@ variable "aws_fg_image" {
 
 variable "aws_lb_listener_arn" {
   description = "ARN of the AWS LB listener to associated with the service target group"
-  default = "arn:aws:elasticloadbalancing:us-west-2:445837347542:listener/app/pds-en-ecs/7870b4ad486ca87b/085568f01bd7a139"
+  # default = "arn:aws:elasticloadbalancing:us-west-2:445837347542:listener/app/pds-en-ecs/7870b4ad486ca87b/085568f01bd7a139"
 }
 
 variable "http_header_forward_name" {


### PR DESCRIPTION
## 🗒️ Summary
Fix issue whereby the CloudFront function should not rewrite search API URIs that do not contain a command. This will allow us to redirect to documentation if no command is specified (see [pds-api #191](https://github.com/NASA-PDS/pds-api/issues/191)