### PR TITLE
Various Registry API fixes

### DIFF
--- a/model/swagger.yml
+++ b/model/swagger.yml
@@ -272,6 +272,32 @@ paths:
       - $ref: "#/components/parameters/Start"
       - $ref: "#/components/parameters/Versions"
 
+  /products:
+    get:
+      tags:
+        - products
+      summary: |
+        returns all PDS data products, including bundles, collections, documentation, context and observational products taht meet all given constraints.
+      operationId: product-list
+      responses:
+        '200':
+          $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
+        '404':
+          $ref: "#/components/responses/Error"
+        '500':
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
+    parameters:
+      - $ref: "#/components/parameters/Fields"
+      - $ref: "#/components/parameters/Keyword"
+      - $ref: "#/components/parameters/Limit"
+      - $ref: "#/components/parameters/Query"
+      - $ref: "#/components/parameters/Sort"
+      - $ref: "#/components/parameters/Start"
+
   /products/{identifier}:
     get:
       tags:
@@ -443,7 +469,7 @@ paths:
       tags:
         - references
       summary: |
-        eturns one or more PDS Products that have the given PDS lid/lidvid as a member.
+        returns one or more PDS Products that have the given PDS lid/lidvid as a member.
       operationId: product-member-of
       responses:
         '200':
@@ -467,7 +493,7 @@ paths:
       tags:
         - references
       summary: |
-        eturns one or more PDS Products that have the given PDS lid/lidvid as a member.
+        returns one or more PDS Products that have the given PDS lid/lidvid as a member.
       operationId: product-member-of-vers
       responses:
         '200':
@@ -538,6 +564,31 @@ paths:
       - $ref: "#/components/parameters/Versions"
 
 # begin deprecated: this is the older API that is clutter
+  /bundles:
+    get:
+      tags:
+        - deprecated
+      summary: deprecated
+      operationId: bundle-list
+      responses:
+        '200':
+          $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
+        '404':
+          $ref: "#/components/responses/Error"
+        '500':
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
+    parameters:
+      - $ref: "#/components/parameters/Fields"
+      - $ref: "#/components/parameters/Keyword"
+      - $ref: "#/components/parameters/Limit"
+      - $ref: "#/components/parameters/Query"
+      - $ref: "#/components/parameters/Sort"
+      - $ref: "#/components/parameters/Start"
+
   /bundles/{identifier}:
     get:
       tags:
@@ -697,6 +748,31 @@ paths:
       - $ref: "#/components/parameters/Fields"
       - $ref: "#/components/parameters/Identifier"
       - $ref: "#/components/parameters/Limit"
+      - $ref: "#/components/parameters/Sort"
+      - $ref: "#/components/parameters/Start"
+
+  /collections:
+    get:
+      tags:
+        - deprecated
+      summary: deprecated
+      operationId: collection-list
+      responses:
+        '200':
+          $ref: "#/components/responses/Plural"
+        '400':
+          $ref: "#/components/responses/Error"
+        '404':
+          $ref: "#/components/responses/Error"
+        '500':
+          $ref: "#/components/responses/Error"
+        '501':
+          $ref: "#/components/responses/Error"
+    parameters:
+      - $ref: "#/components/parameters/Fields"
+      - $ref: "#/components/parameters/Keyword"
+      - $ref: "#/components/parameters/Limit"
+      - $ref: "#/components/parameters/Query"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/LidvidsContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/LidvidsContext.java
@@ -5,4 +5,5 @@ public interface LidvidsContext
 	public String getLidVid();
 	public Integer getLimit();
 	public Integer getStart();
+	public boolean isSummaryOnly();
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaDeprecatedTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaDeprecatedTransmuter.java
@@ -15,6 +15,13 @@ import gov.nasa.pds.api.registry.model.ProductVersionSelector;
 abstract class SwaggerJavaDeprecatedTransmuter extends SwaggerJavaProductsTransmuter implements BundlesApi, CollectionsApi, ProductsApi
 {
 	@Override
+	public ResponseEntity<Object> bundleList(@Valid List<String> fields, @Valid List<String> keywords, 
+			@Min(0) @Valid Integer limit, @Valid String q, @Valid List<String> sort,
+			@Min(0) @Valid Integer start) {
+		return super.classList("bundles", fields, keywords, limit, q, sort, start);
+	}
+
+	@Override
 	public ResponseEntity<Object> bundlesLidvid(String identifier, @Valid List<String> fields) {
 		return this.processs(new Standard(), new URIParameters()
 				.setGroup("bundles")
@@ -73,6 +80,13 @@ abstract class SwaggerJavaDeprecatedTransmuter extends SwaggerJavaProductsTransm
 	}
 
 	@Override
+	public ResponseEntity<Object> collectionList(@Valid List<String> fields, @Valid List<String> keywords, 
+			@Min(0) @Valid Integer limit, @Valid String q, @Valid List<String> sort,
+			@Min(0) @Valid Integer start) {
+		return super.classList("collections", fields, keywords, limit, q, sort, start);
+	}
+
+	@Override
 	public ResponseEntity<Object> collectionsLidvid(String identifier, @Valid List<String> fields) {
 		return this.processs(new Standard(), new URIParameters()
 				.setGroup("collections")
@@ -97,7 +111,7 @@ abstract class SwaggerJavaDeprecatedTransmuter extends SwaggerJavaProductsTransm
 	public ResponseEntity<Object> collectionsLidvidBundles(String identifier,
 			@Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
 			@Min(0) @Valid Integer start) {
-		return this.classMemberOf("collection", identifier, fields, limit, sort, start);
+		return this.classMemberOf("collections", identifier, fields, limit, sort, start);
 	}
 
 	@Override

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaProductsTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaProductsTransmuter.java
@@ -13,6 +13,13 @@ import gov.nasa.pds.api.registry.model.ProductVersionSelector;
 abstract class SwaggerJavaProductsTransmuter extends SwaggerJavaClassesTransmuter implements ProductsApi
 {
 	@Override
+	public ResponseEntity<Object> productList(@Valid List<String> fields, @Valid List<String> keywords, 
+			@Min(0) @Valid Integer limit, @Valid String q, @Valid List<String> sort,
+			@Min(0) @Valid Integer start) {
+		return super.classList("any", fields, keywords, limit, q, sort, start);
+	}
+
+	@Override
 	public ResponseEntity<Object> productMemberOf(String identifier, @Valid List<String> fields,
 			@Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
 		return this.processs(new Member(false, false), new URIParameters()

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
@@ -145,6 +145,14 @@ public class SwaggerJavaTransmuter extends SwaggerJavaDeprecatedTransmuter imple
     }
 
 	@Override
+	public ResponseEntity<Object> bundleList(@Valid List<String> fields, @Valid List<String> keywords, 
+			@Min(0) @Valid Integer limit, @Valid String q, @Valid List<String> sort,
+			@Min(0) @Valid Integer start) {
+		// TODO Auto-generated method stub
+		return super.bundleList(fields, keywords, limit, q, sort, start);
+	}
+
+	@Override
 	public ResponseEntity<Object> bundlesLidvid(String identifier, @Valid List<String> fields) {
 		// TODO Auto-generated method stub
 		return super.bundlesLidvid(identifier, fields);
@@ -192,6 +200,14 @@ public class SwaggerJavaTransmuter extends SwaggerJavaDeprecatedTransmuter imple
 	}
 
 	@Override
+	public ResponseEntity<Object> collectionList(@Valid List<String> fields, @Valid List<String> keywords, 
+			@Min(0) @Valid Integer limit, @Valid String q, @Valid List<String> sort,
+			@Min(0) @Valid Integer start) {
+		// TODO Auto-generated method stub
+		return super.collectionList(fields, keywords, limit, q, sort, start);
+	}
+
+	@Override
 	public ResponseEntity<Object> collectionsLidvid(String identifier, @Valid List<String> fields) {
 		// TODO Auto-generated method stub
 		return super.collectionsLidvid(identifier, fields);
@@ -236,6 +252,14 @@ public class SwaggerJavaTransmuter extends SwaggerJavaDeprecatedTransmuter imple
 			@Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
 		// TODO Auto-generated method stub
 		return super.collectionsLidvidProductsLatest(identifier, fields, limit, sort, start);
+	}
+
+	@Override
+	public ResponseEntity<Object> productList(@Valid List<String> fields, @Valid List<String> keywords, 
+			@Min(0) @Valid Integer limit, @Valid String q, @Valid List<String> sort,
+			@Min(0) @Valid Integer start) {
+		// TODO Auto-generated method stub
+		return super.productList(fields, keywords, limit, q, sort, start);
 	}
 
 	@Override

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
@@ -31,7 +31,7 @@ import gov.nasa.pds.api.registry.search.RequestBuildContextFactory;
 class URIParameters implements UserContext
 {
 	private boolean verifyClassAndId = false;
-	private String accept = "applicaation/json";
+	private String accept = "application/json";
 	private List<String> fields = new ArrayList<String>();
 	private String group = "";
 	private String identifier = "";

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
@@ -30,6 +30,8 @@ import gov.nasa.pds.api.registry.search.RequestBuildContextFactory;
  */
 class URIParameters implements UserContext
 {
+	private static final int SUMMARY_SAMPLE_SIZE = 100;
+	
 	private boolean verifyClassAndId = false;
 	private String accept = "application/json";
 	private List<String> fields = new ArrayList<String>();
@@ -38,6 +40,7 @@ class URIParameters implements UserContext
 	private List<String> keywords = new ArrayList<String>();
 	private String lidvid = "";
 	private Integer limit = Integer.valueOf(0);
+	private boolean summaryOnly = true;
 	private String query = "";
 	private ProductVersionSelector selector = ProductVersionSelector.LATEST;
 	private List<String> sort = new ArrayList<String>();
@@ -69,6 +72,8 @@ class URIParameters implements UserContext
 	public boolean getVerifyClassAndId() { return verifyClassAndId; }
 	@Override
 	public String getVersion() { return version; }
+	@Override
+	public boolean isSummaryOnly() { return summaryOnly; }
 
 	public URIParameters setAccept(String accept)
 	{
@@ -97,7 +102,21 @@ class URIParameters implements UserContext
 	}
 	public URIParameters setLimit(Integer limit)
 	{
-		if (limit != null) this.limit = limit;
+		/* 
+		 * Note: Not too happy w/ having to put behavioral logic in a utility/container class, but
+		 * there are just way too many places where this information is necessary and rather than
+		 * duplicate it everywhere, this is the best place, for now, as it is the common object
+		 * shared across them all.
+		 */
+		if (limit != null) {
+			if(limit == 0) {
+				summaryOnly = true;
+				this.limit = Integer.valueOf(SUMMARY_SAMPLE_SIZE);
+			} else {
+				this.limit = limit;
+				summaryOnly = false;
+			}
+		}
 		return this;
 	}
 	public URIParameters setLidVid(ControlContext control) throws IOException, LidVidNotFoundException

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RequestAndResponseContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RequestAndResponseContext.java
@@ -35,18 +35,6 @@ public class RequestAndResponseContext implements RequestBuildContext,RequestCon
 {
     private static final Logger log = LoggerFactory.getLogger(RequestAndResponseContext.class);
 
-	/*
-	 * Summary only is now specified as limit=0. However, by not retrieving any data from the registry, the list of
-	 * properties (i.e. the summary) cannot be constructed. This constant is the default limit/size used in the case 
-	 * summary-only has been requested. 
-	 *
-	 * It would be better if we could access the default defined in swagger.yml, but that is only available a couple 
-	 * of call levels above here. The code could be refectored such that summary only is determined at that level,
-	 * but it would be a significant change and require each endpoint method to handle it rather than centralized
-	 * here.
-	 */
-	private static final int SUMMARY_SAMPLE_SIZE = 100; 
-
     final private long begin_processing = System.currentTimeMillis();
     final private ControlContext controlContext;
 	final private String queryString;

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/Unlimited.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/Unlimited.java
@@ -15,5 +15,8 @@ class Unlimited implements LidvidsContext
 
 	@Override
 	public Integer getStart() { return 0; }
+	
+	@Override
+	public boolean isSummaryOnly() { return false; }
 
 }


### PR DESCRIPTION
## 🗒️ Summary
Primarily addresses registry-api #178 - restore /products, /collections and /bundles endpoints which were removed in the most recent overhaul of the API. It also addresses registry-api #179 where limit=0 was not working as a replacement for summary-only=true. Various other tweaks mostly involving typos, some of which did affect functionality.

I will warn you, the liberal mix of tabs and spaces is horrendous in this repo - beyond making sure tabs were used in these fixes, none of the existing mess was touched.

## ♻️ Related Issues
    * in this repo:
        - fixes #178
        - fixes #179
        - fixes #152 
    * other repos:
        - fixes NASA-PDS/pds-api#173
