### PR TITLE
pds-api-200: performance measurement

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
@@ -94,6 +94,7 @@ public class SwaggerJavaTransmuter extends SwaggerJavaDeprecatedTransmuter imple
 
 	protected ResponseEntity<Object> processs (EndpointHandler handler, URIParameters parameters)
 	{
+		long begin = System.currentTimeMillis();
         try
         {
         	parameters.setAccept(this.request.getHeader("Accept")).setLidVid(this);
@@ -136,6 +137,7 @@ public class SwaggerJavaTransmuter extends SwaggerJavaDeprecatedTransmuter imple
         	log.error("Group name not implemented", e);
         	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_ACCEPTABLE);
         }
+        finally { log.info("Transmuter processing of request took: " + (System.currentTimeMillis() - begin) + " ms"); }
 	}
 
 	private boolean proxyRunsOnDefaultPort()

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/LidVidUtils.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/LidVidUtils.java
@@ -138,7 +138,7 @@ public class LidVidUtils
     }
 
 	public static void verify (ControlContext control, UserContext user)
-			throws IOException, LidVidMismatchException, UnknownGroupNameException
+			throws IOException, LidVidMismatchException, LidVidNotFoundException, UnknownGroupNameException
 	{
 		ReferencingLogicTransmuter expected_rlt = ReferencingLogicTransmuter.getBySwaggerGroup(user.getGroup());
 			

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/QuickSearch.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/QuickSearch.java
@@ -4,34 +4,36 @@ import java.io.IOException;
 import java.util.List;
 
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
 
 import gov.nasa.pds.api.registry.ConnectionContext;
+import gov.nasa.pds.api.registry.exceptions.LidVidNotFoundException;
 
 public class QuickSearch
 {
-	final private static Object get(ConnectionContext connection, String index, String lidvid, String name) throws IOException
+	final private static Object get(ConnectionContext connection, String index, String lidvid, String name) throws IOException, LidVidNotFoundException
 	{
 		SearchRequest request = new SearchRequestFactory(RequestConstructionContextFactory.given(lidvid), connection)
 				.build(RequestBuildContextFactory.given(name), index);
-		return connection.getRestHighLevelClient().search(request, RequestOptions.DEFAULT)
-				.getHits()
-				.getAt(0)
-				.getSourceAsMap()
-				.get(name);
+		SearchResponse result = connection.getRestHighLevelClient().search(request, RequestOptions.DEFAULT);
+		
+		if (result.getHits().getTotalHits().value == 0L) throw new LidVidNotFoundException(lidvid);
+
+		return result.getHits().getAt(0).getSourceAsMap().get(name);
 	}
 
-	final public static String getValue (ConnectionContext connection, String lidvid, String name) throws IOException
+	final public static String getValue (ConnectionContext connection, String lidvid, String name) throws IOException, LidVidNotFoundException
 	{ return (String)QuickSearch.get(connection, connection.getRegistryIndex(), lidvid, name); }
 
-	final public static String getValue (ConnectionContext connection, String index, String lidvid, String name) throws IOException
+	final public static String getValue (ConnectionContext connection, String index, String lidvid, String name) throws IOException, LidVidNotFoundException
 	{ return (String)QuickSearch.get(connection, index, lidvid, name); }
 
 	@SuppressWarnings("unchecked")
-	final public static List<String> getValues (ConnectionContext connection, String lidvid, String name) throws IOException
+	final public static List<String> getValues (ConnectionContext connection, String lidvid, String name) throws IOException, LidVidNotFoundException
 	{ return (List<String>)QuickSearch.get(connection, connection.getRegistryIndex(), lidvid, name); }
 
 	@SuppressWarnings("unchecked")
-	final public static List<String> getValues (ConnectionContext connection, String index, String lidvid, String name) throws IOException
+	final public static List<String> getValues (ConnectionContext connection, String index, String lidvid, String name) throws IOException, LidVidNotFoundException
 	{ return (List<String>)QuickSearch.get(connection, index, lidvid, name); }
 }


### PR DESCRIPTION
## 🗒️ Summary

Minor changes. One, add a log message for a simplistic measurement of the registry-api performance. Two add some more error handling.

## ⚙️ Test Data and/or Report

mean registry-api rate: 230000 products/min
mean curl rate: 210000 products/min

## ♻️ Related Issues
NASA-PDS/pds-api#200
