### PR TITLE
Properties array 203

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -61,6 +61,7 @@
       <plugin>
 	<groupId>org.springframework.boot</groupId>
 	<artifactId>spring-boot-maven-plugin</artifactId>
+	<version>2.7.5</version>
 	<executions>
 	  <execution>
 	    <goals>

--- a/service/src/main/java/gov/nasa/pds/api/registry/configuration/SwaggerDocumentationConfig.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/configuration/SwaggerDocumentationConfig.java
@@ -15,6 +15,8 @@ import springfox.documentation.spring.web.plugins.Docket;
 @javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2020-07-24T09:48:37.812-07:00[America/Los_Angeles]")
 @Configuration
 public class SwaggerDocumentationConfig {
+	
+	
 
 	@Value("${registry.service.version:undefined}")
 	private String version;

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/EntityProduct.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/EntityProduct.java
@@ -38,12 +38,12 @@ public class EntityProduct {
 	private String productClass;
 	
 	@JsonProperty("pds:Time_Coordinates/pds:start_date_time")
-	private String start_date_time;
+	private List<String> start_date_time; //test
 	
 	@JsonProperty("pds:Time_Coordinates/pds:stop_date_time")
-	private String stop_date_time;
+	private List<String> stop_date_time; //test
 
-	@JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+	@JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) 
 	@JsonProperty("pds:Modification_Detail/pds:modification_date")
     private List<String> modification_date;
     
@@ -71,7 +71,8 @@ public class EntityProduct {
 	private String version; 
 	
 	@JsonProperty("ops:Label_File_Info/ops:file_ref")
-	private String pds4FileReference;
+	private List<String> pds4FileReference; //test
+	
 	
 	@JsonProperty("ops:Tracking_Meta/ops:archive_status")
 	private String archive_status;
@@ -120,15 +121,15 @@ public class EntityProduct {
 
 	
 	public String getPDS4FileRef() {
-		return this.pds4FileReference;
+		return this.pds4FileReference.get(0);
 	}
 	
 	public String getStartDateTime() {
-		return start_date_time;
+		return start_date_time.get(0);
 	}
 
 	public String getStopDateTime() {
-		return stop_date_time;
+		return stop_date_time.get(0);
 	}
 
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/Pds4ProductFactory.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/Pds4ProductFactory.java
@@ -62,14 +62,21 @@ public class Pds4ProductFactory
         if(fieldMap == null) return prod;
                 
         // Pds4 JSON BLOB
+        String blob = null;
         String decoded_blob = null;
         try
         { 
-        	if (isJSON) decoded_blob = BlobUtil.blobToString(String.valueOf(fieldMap.get(FLD_JSON_BLOB)));
+        	
+        	if (isJSON) 
+        	{
+        		blob = getVal(fieldMap,FLD_JSON_BLOB);
+        		decoded_blob = BlobUtil.blobToString(String.valueOf(blob));
+        	}
         	else
         	{
         		int first,last;
-        		decoded_blob = BlobUtil.blobToString(String.valueOf(fieldMap.get(FLD_XML_BLOB)));
+        		blob = getVal(fieldMap, FLD_XML_BLOB);
+        		decoded_blob = BlobUtil.blobToString(String.valueOf(blob));
         		decoded_blob = decoded_blob.replaceAll("\r", "");
         		first = decoded_blob.indexOf("<?");
         		while (0 <= first)
@@ -98,7 +105,9 @@ public class Pds4ProductFactory
     {
         Pds4Metadata meta = new Pds4Metadata();
 
-        meta.setNodeName((String)fieldMap.get(FLD_NODE_NAME));
+        ArrayList<String> nodeNames = (ArrayList<String>)fieldMap.get(FLD_NODE_NAME);
+        String nodeName = nodeNames.get(0);
+        meta.setNodeName(nodeName);
         meta.setOpsLabelFileInfo(createLabelFile(fieldMap));
         meta.setOpsDataFiles(createDataFiles(fieldMap));
         meta.setOpsTrackingMeta(createTrackingMeta(fieldMap));
@@ -106,23 +115,36 @@ public class Pds4ProductFactory
     }
     
     
+    @SuppressWarnings("unchecked")
+	private static String getVal(Map<String, Object> fieldMap, String fieldName)
+    {
+    	return ((ArrayList<String>)fieldMap.get(fieldName)).get(0);
+    }
+    
     private static Pds4MetadataOpsLabelFileInfo createLabelFile(Map<String, Object> fieldMap)
     {
-        Object obj = fieldMap.get(FLD_LABEL_FILE_NAME);
-        if(obj == null) return null;
+        ArrayList<String> vals = (ArrayList<String>)fieldMap.get(FLD_LABEL_FILE_NAME);
+        
+        if(vals == null) return null;
 
         Pds4MetadataOpsLabelFileInfo item = new Pds4MetadataOpsLabelFileInfo();
 
-        String val = (String)obj;
+        String val = vals.get(0);
         item.setOpsfileName(val);
-        val = (String)fieldMap.get(FLD_LABEL_FILE_CREATION);
+        
+        
+        val = getVal(fieldMap, FLD_LABEL_FILE_CREATION);
         item.setOpscreationDate(val);
-        val = (String)fieldMap.get(FLD_LABEL_FILE_REF);
+        
+        val = getVal(fieldMap, FLD_LABEL_FILE_REF);
         item.setOpsfileRef(val);
-        val = (String)fieldMap.get(FLD_LABEL_FILE_SIZE);
+        
+        val = getVal(fieldMap, FLD_LABEL_FILE_SIZE);
         item.setOpsfileSize(val);
-        val = (String)fieldMap.get(FLD_LABEL_FILE_MD5);
+        
+        val = getVal(fieldMap, FLD_LABEL_FILE_MD5);
         item.setOpsmd5Checksum(val);
+        
         return item;
     }
 
@@ -130,33 +152,21 @@ public class Pds4ProductFactory
 	private static List<Pds4MetadataOpsDataFiles> createDataFiles(Map<String, Object> fieldMap)
     {
         List<Pds4MetadataOpsDataFiles> items = new ArrayList<Pds4MetadataOpsDataFiles>();
-        Object val = fieldMap.get(FLD_DATA_FILE_NAME);
+        ArrayList<String> vals = (ArrayList<String>)fieldMap.get(FLD_DATA_FILE_NAME);
         Pds4MetadataOpsDataFiles item = new Pds4MetadataOpsDataFiles();
         
-        if (val instanceof List)
+        
+        for (int i=0 ; i < ((List)vals).size() ; i++)
         {
-        	for (int i=0 ; i < ((List)val).size() ; i++)
-        	{
-            	item.setOpsfileName((String)((List)fieldMap.get(FLD_DATA_FILE_CREATION)).get(i));
-            	item.setOpscreationDate((String)((List)fieldMap.get(FLD_DATA_FILE_CREATION)).get(i));
-            	item.opsfileRef((String)((List)fieldMap.get(FLD_DATA_FILE_REF)).get(i));
-            	item.setOpsfileSize((String)((List)fieldMap.get(FLD_DATA_FILE_SIZE)).get(i));
-            	item.setOpsmd5Checksum((String)((List)fieldMap.get(FLD_DATA_FILE_MD5)).get(i));
-            	item.setOpsmimeType((String)((List)fieldMap.get(FLD_DATA_FILE_MIME_TYPE)).get(i));
-            	items.add(item);
-            	item = new Pds4MetadataOpsDataFiles();
-        	}
-        }
-        else
-        {
-        	item.setOpsfileName((String)val);
-        	item.setOpscreationDate((String)fieldMap.get(FLD_DATA_FILE_CREATION));
-        	item.opsfileRef((String)fieldMap.get(FLD_DATA_FILE_REF));
-        	item.setOpsfileSize((String)fieldMap.get(FLD_DATA_FILE_SIZE));
-        	item.setOpsmd5Checksum((String)fieldMap.get(FLD_DATA_FILE_MD5));
-        	item.setOpsmimeType((String)fieldMap.get(FLD_DATA_FILE_MIME_TYPE));
+        	item.setOpsfileName((String)((List)fieldMap.get(FLD_DATA_FILE_CREATION)).get(i));
+        	item.setOpscreationDate((String)((List)fieldMap.get(FLD_DATA_FILE_CREATION)).get(i));
+        	item.opsfileRef((String)((List)fieldMap.get(FLD_DATA_FILE_REF)).get(i));
+        	item.setOpsfileSize((String)((List)fieldMap.get(FLD_DATA_FILE_SIZE)).get(i));
+        	item.setOpsmd5Checksum((String)((List)fieldMap.get(FLD_DATA_FILE_MD5)).get(i));
+        	item.setOpsmimeType((String)((List)fieldMap.get(FLD_DATA_FILE_MIME_TYPE)).get(i));
         	items.add(item);
-        }
+        	item = new Pds4MetadataOpsDataFiles();
+    	}
         return items;
     }
     

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -32,4 +32,5 @@ openSearch.sslCertificateCNVerification=true
 filter.archiveStatus=archived,certified
 
 # source version from maven
+# need to be updated with actual value when runs outside of maven
 registry.service.version=@project.version@

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -26,10 +26,10 @@ openSearch.username=admin
 openSearch.password=admin
 openSearch.ssl=true
 # use only for development purpose, left it to true otherwise
-openSearch.sslCertificateCNVerification=false
+openSearch.sslCertificateCNVerification=true
 
 # Only show products with following archive statuses
 filter.archiveStatus=archived,certified
 
 # source version from maven
-registry.service.version=${project.version}
+registry.service.version=@project.version@

--- a/service/src/main/resources/swagger-ui/swagger-initializer.js
+++ b/service/src/main/resources/swagger-ui/swagger-initializer.js
@@ -3,7 +3,7 @@ window.onload = function() {
 
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
   window.ui = SwaggerUIBundle({
-    url: "http://localhost:8080/api-docs",
+    url: "/api-docs",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
## 🗒️ Summary
After upgrade of harvest/registry-common, all the properties in the source structure of the opensearch documents are arrays. This pull request enable the API to work with that.

## ⚙️ Test Data and/or Report
Test with latest harvest/registry-common, you can use the dev version of registry docker compose to deploy them and start with an initialized database. see https://github.com/NASA-PDS/registry/tree/main/docker

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Fixes #203 
