### PR TITLE
Resolve software-issues-repo#53

### DIFF
--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -85,7 +85,7 @@ jobs:
                 name: 🫙 Jar and Tag Determination
                 id: jartag
                 run: |
-                    echo "jar_file==$(ls ./service/target/*.jar)" >> $GITHUB_OUTPUT
+                    echo "jar_file=$(ls ./service/target/*.jar)" >> $GITHUB_OUTPUT
                     echo "image_tag=$(echo ${{github.ref}} | awk -F/ '{print $NF}')" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification


### PR DESCRIPTION
## 🗒️ Summary

Minor correction to handling of inter-step output variable (double-`==` → single `=`).

## ⚙️ Test Data and/or Report

Can't run GitHub Actions in insolation, especially not for a stable workflow.

## ♻️ Related Issues

- https://github.com/NASA-PDS/software-issues-repo/issues/53
