### PR TITLE
Provenance script tweaks

### DIFF
--- a/support/provenance.py
+++ b/support/provenance.py
@@ -84,8 +84,6 @@ def get_historic(provenance: {str: str}, reset: bool) -> {str: str}:  # TODO: po
         for index, lidvid in enumerate(lidvids[1:]):
             if reset or not provenance[lidvid]:
                 history[lidvid] = lidvids[index]
-            pass  # TODO: Make sure this is extraneous and not intended to do something
-        pass  # TODO: Make sure this is extraneous and not intended to do something
 
     log.info(f'found {len(history)} products needing update of a {count} full history of {len(provenance)} total products')
 
@@ -126,14 +124,11 @@ def trawl_registry(host: HOST) -> {str: str}:  # TODO: populate comment and rena
         percent_hit = int(round(len(provenance) / hits * 100))
         log.info(f'   progress: {len(provenance)} of {hits} ({percent_hit}%)')
 
-        pass
-
     if 'scroll_id' in query:
         path = '_search/scroll/' + query['scroll_id']
         requests.delete(urllib.parse.urljoin(host.url, path),
                         auth=(host.username, host.password),
                         verify=host.verify)
-        pass
 
     log.info('finished trawling')
 
@@ -152,7 +147,6 @@ def update_docs(host: HOST, history: {str: str}):
     for lidvid, supersede in history.items():
         bulk.append(json.dumps({'update': {'_id': lidvid}}))
         bulk.append(json.dumps({'doc': {'ops:Provenance/ops:superseded_by': supersede}}))
-        pass
 
     bulk = '\n'.join(bulk) + '\n'
     response = requests.put(urllib.parse.urljoin(host.url, path),
@@ -169,11 +163,8 @@ def update_docs(host: HOST, history: {str: str}):
                 if 'error' in item:
                     log.error('update error (%d): %s', item['status'],
                               str(item['error']))
-                    pass
-                pass
         else:
             log.info('bulk update were successful')
-    return
 
 
 if __name__ == '__main__':

--- a/support/provenance.py
+++ b/support/provenance.py
@@ -30,43 +30,7 @@ def _vid_as_tuple_of_int(lidvid: str):
     return (int(M), int(m))
 
 
-def cli():
-    ap = argparse.ArgumentParser(description='''Update the provenance of products with more than one VID
-
-The program sweeps through the registry index to find all the lidvids and existing provenance. It then builds up the updates necessary to mark the newly superseded products accordingly.
-''',
-                                 epilog='''EXAMPLES:
-
-- command for opensearch running in a container with the sockets published at 9200 for data ingested for full day March 11, 2020:
-
-  provenance.py -b https://localhost:9200 -p admin -u admin
-
-- getting more help on availables arguments and what is expected:
-
-  provenance.py --help
-
-- command for opensearch running in a cluster
-
-  provenance.py -b https://search-en-prod-di7dor7quy7qwv3husi2wt5tde.us-west-2.es.amazonaws.com -c naif-prod-ccs rms-prod sbnumd-prod-ccs geo-prod-ccs atm-prod-ccs sbnpsi-prod-ccs img-prod-ccs -u admin -p admin
-''',
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument('-b', '--base-URL', required=True, type=str)
-    ap.add_argument('-c', '--cluster-nodes', default=[], nargs='*',
-                    help='names of opensearch cluster nodes that will be parsed by opensearch')
-    ap.add_argument('-l', '--log-file', default='/dev/stdout', required=False,
-                    help='file to write the log messages [%(default)s]')
-    ap.add_argument('-L', '--log-level', default='ERROR', required=False,
-                    type=_log_level,
-                    help='Python logging level as an int or string like INFO for logging.INFO [%(default)s]')
-    ap.add_argument('-p', '--password', default=None, required=False,
-                    help='password to login to opensearch leaving it blank if opensearch does not require login')
-    ap.add_argument('-r', '--reset', action='store_true', default=False,
-                    help='ignore existing provenance building it from scratch')
-    ap.add_argument('-u', '--username', default=None, required=False,
-                    help='username to login to opensearch leaving it blank if opensearch does not require login')
-    ap.add_argument('-v', '--verify', action='store_true', default=False,
-                    help='verify the host certificates')
-    args = ap.parse_args()
+def run(args: argparse.Namespace):
     logging.basicConfig(filename=args.log_file, level=args.log_level,
                         format='%(asctime)s::%(levelname)s::%(message)s')
     log.info('starting CLI processing')
@@ -175,4 +139,42 @@ def update_docs(host: HOST, history: {str: str}):
     return
 
 
-if __name__ == '__main__': cli()
+if __name__ == '__main__':
+    ap = argparse.ArgumentParser(description='''Update the provenance of products with more than one VID
+
+    The program sweeps through the registry index to find all the lidvids and existing provenance. It then builds up the updates necessary to mark the newly superseded products accordingly.
+    ''',
+                                 epilog='''EXAMPLES:
+
+    - command for opensearch running in a container with the sockets published at 9200 for data ingested for full day March 11, 2020:
+
+      provenance.py -b https://localhost:9200 -p admin -u admin
+
+    - getting more help on availables arguments and what is expected:
+
+      provenance.py --help
+
+    - command for opensearch running in a cluster
+
+      provenance.py -b https://search-en-prod-di7dor7quy7qwv3husi2wt5tde.us-west-2.es.amazonaws.com -c naif-prod-ccs rms-prod sbnumd-prod-ccs geo-prod-ccs atm-prod-ccs sbnpsi-prod-ccs img-prod-ccs -u admin -p admin
+    ''',
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('-b', '--base-URL', required=True, type=str)
+    ap.add_argument('-c', '--cluster-nodes', default=[], nargs='*',
+                    help='names of opensearch cluster nodes that will be parsed by opensearch')
+    ap.add_argument('-l', '--log-file', default='/dev/stdout', required=False,
+                    help='file to write the log messages [%(default)s]')
+    ap.add_argument('-L', '--log-level', default='ERROR', required=False,
+                    type=_log_level,
+                    help='Python logging level as an int or string like INFO for logging.INFO [%(default)s]')
+    ap.add_argument('-p', '--password', default=None, required=False,
+                    help='password to login to opensearch leaving it blank if opensearch does not require login')
+    ap.add_argument('-r', '--reset', action='store_true', default=False,
+                    help='ignore existing provenance building it from scratch')
+    ap.add_argument('-u', '--username', default=None, required=False,
+                    help='username to login to opensearch leaving it blank if opensearch does not require login')
+    ap.add_argument('-v', '--verify', action='store_true', default=False,
+                    help='verify the host certificates')
+    args = ap.parse_args()
+
+    run(args)

--- a/support/provenance.py
+++ b/support/provenance.py
@@ -7,9 +7,7 @@ import logging
 from typing import Union, List
 
 log = logging.getLogger('provenance')
-import os
 import requests
-import sys
 import urllib.parse
 
 requests.packages.urllib3.disable_warnings()
@@ -57,7 +55,6 @@ def run(
         reset: bool = False,
         log_filepath: Union[str, None] = None,
         log_level: int = logging.INFO):
-
     configure_logging(filepath=log_filepath, log_level=log_level)
 
     log.info('starting CLI processing')
@@ -93,7 +90,8 @@ def get_historic(provenance: {str: str}, reset: bool) -> {str: str}:  # TODO: po
             if reset or not provenance[lidvid]:
                 history[lidvid] = lidvids[index]
 
-    log.info(f'found {len(history)} products needing update of a {count} full history of {len(provenance)} total products')
+    log.info(
+        f'found {len(history)} products needing update of a {count} full history of {len(provenance)} total products')
 
     return history
 

--- a/support/provenance.py
+++ b/support/provenance.py
@@ -3,7 +3,9 @@
 import argparse
 import collections
 import json
-import logging; log = logging.getLogger('provenance')
+import logging;
+
+log = logging.getLogger('provenance')
 import os
 import requests
 import sys
@@ -11,17 +13,22 @@ import urllib.parse
 
 requests.packages.urllib3.disable_warnings()
 
-HOST = collections.namedtuple ('HOST', ['nodes', 'password', 'url', 'username',
-                                        'verify'])
+HOST = collections.namedtuple('HOST', ['nodes', 'password', 'url', 'username',
+                                       'verify'])
 
-def _log_level (input:str)->int:
-    try: result = int(input)
-    except ValueError: result = getattr (logging, input)
+
+def _log_level(input: str) -> int:
+    try:
+        result = int(input)
+    except ValueError:
+        result = getattr(logging, input)
     return result
 
-def _vid_as_tuple_of_int (lidvid:str):
-    M,m = lidvid.split('::')[1].split('.')
-    return (int(M),int(m))
+
+def _vid_as_tuple_of_int(lidvid: str):
+    M, m = lidvid.split('::')[1].split('.')
+    return (int(M), int(m))
+
 
 def cli():
     ap = argparse.ArgumentParser(description='''Update the provenance of products with more than one VID
@@ -31,7 +38,7 @@ The program sweeps through the registry index to find all the lidvids and existi
                                  epilog='''EXAMPLES:
 
 - command for opensearch running in a container with the sockets published at 9200 for data ingested for full day March 11, 2020:
-                                 
+
   provenance.py -b https://localhost:9200 -p admin -u admin
 
 - getting more help on availables arguments and what is expected:
@@ -43,112 +50,117 @@ The program sweeps through the registry index to find all the lidvids and existi
   provenance.py -b https://search-en-prod-di7dor7quy7qwv3husi2wt5tde.us-west-2.es.amazonaws.com -c naif-prod-ccs rms-prod sbnumd-prod-ccs geo-prod-ccs atm-prod-ccs sbnpsi-prod-ccs img-prod-ccs -u admin -p admin
 ''',
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument ('-b', '--base-URL', required=True, type=str)
-    ap.add_argument ('-c', '--cluster-nodes', default=[], nargs='*',
-                     help='names of opensearch cluster nodes that will be parsed by opensearch')
-    ap.add_argument ('-l', '--log-file', default='/dev/stdout', required=False,
-                     help='file to write the log messages [%(default)s]')
-    ap.add_argument ('-L', '--log-level', default='ERROR', required=False,
-                     type=_log_level, help='Python logging level as an int or string like INFO for logging.INFO [%(default)s]')
-    ap.add_argument ('-p', '--password', default=None, required=False,
-                     help='password to login to opensearch leaving it blank if opensearch does not require login')
-    ap.add_argument ('-r', '--reset', action='store_true', default=False,
-                     help='ignore existing provenance building it from scratch')
-    ap.add_argument ('-u', '--username', default=None, required=False,
-                     help='username to login to opensearch leaving it blank if opensearch does not require login')
-    ap.add_argument ('-v', '--verify', action='store_true', default=False,
-                     help='verify the host certificates')
+    ap.add_argument('-b', '--base-URL', required=True, type=str)
+    ap.add_argument('-c', '--cluster-nodes', default=[], nargs='*',
+                    help='names of opensearch cluster nodes that will be parsed by opensearch')
+    ap.add_argument('-l', '--log-file', default='/dev/stdout', required=False,
+                    help='file to write the log messages [%(default)s]')
+    ap.add_argument('-L', '--log-level', default='ERROR', required=False,
+                    type=_log_level,
+                    help='Python logging level as an int or string like INFO for logging.INFO [%(default)s]')
+    ap.add_argument('-p', '--password', default=None, required=False,
+                    help='password to login to opensearch leaving it blank if opensearch does not require login')
+    ap.add_argument('-r', '--reset', action='store_true', default=False,
+                    help='ignore existing provenance building it from scratch')
+    ap.add_argument('-u', '--username', default=None, required=False,
+                    help='username to login to opensearch leaving it blank if opensearch does not require login')
+    ap.add_argument('-v', '--verify', action='store_true', default=False,
+                    help='verify the host certificates')
     args = ap.parse_args()
     logging.basicConfig(filename=args.log_file, level=args.log_level,
                         format='%(asctime)s::%(levelname)s::%(message)s')
-    log.info ('starting CLI processing')
+    log.info('starting CLI processing')
     host = HOST(args.cluster_nodes, args.password, args.base_URL, args.username,
                 args.verify)
-    provenance = troll_registry (host)
-    updates = get_historic (provenance, args.reset)
-    if updates: update_docs (host, updates)
-    log.info ('completed CLI processing')
+    provenance = troll_registry(host)
+    updates = get_historic(provenance, args.reset)
+    if updates: update_docs(host, updates)
+    log.info('completed CLI processing')
     return
 
-def get_historic (provenance:{str:str}, reset:bool)->{str:str}:
-    log.info ('starting search for history')
-    log.info ('   reduce lidvids to unique lids')
+
+def get_historic(provenance: {str: str}, reset: bool) -> {str: str}:
+    log.info('starting search for history')
+    log.info('   reduce lidvids to unique lids')
     lids = sorted({lidvid.split('::')[0] for lidvid in provenance})
-    log.info ('   aggregate lidvids into lid buckets')
-    aggregates = {lid:[] for lid in lids}
-    for lidvid in provenance: aggregates[lidvid.split('::')[0]].append (lidvid)
-    log.info ('   process those with history')
+    log.info('   aggregate lidvids into lid buckets')
+    aggregates = {lid: [] for lid in lids}
+    for lidvid in provenance: aggregates[lidvid.split('::')[0]].append(lidvid)
+    log.info('   process those with history')
     count = 0
     history = {}
-    for lidvids in filter (lambda l:1<len(l), aggregates.values()):
+    for lidvids in filter(lambda l: 1 < len(l), aggregates.values()):
         count += len(lidvids)
-        lidvids.sort (key=_vid_as_tuple_of_int, reverse=True)
-        for index,lidvid in enumerate(lidvids[1:]):
+        lidvids.sort(key=_vid_as_tuple_of_int, reverse=True)
+        for index, lidvid in enumerate(lidvids[1:]):
             if reset or not provenance[lidvid]: history[lidvid] = lidvids[index]
             pass
         pass
-    log.info ('found %d products needing update of a %d full history of %d total products', len(history), count, len(provenance))
+    log.info('found %d products needing update of a %d full history of %d total products', len(history), count,
+             len(provenance))
     return history
 
-def troll_registry (host:HOST)->{str:str}:
-    log.info ('start trolling')
+
+def troll_registry(host: HOST) -> {str: str}:
+    log.info('start trolling')
     cluster = [node + ":registry" for node in host.nodes]
     key = 'ops:Provenance/ops:superseded_by'
     more_data = True
-    path = ','.join (['registry'] + cluster) + '/_search?scroll=10m'
+    path = ','.join(['registry'] + cluster) + '/_search?scroll=10m'
     provenance = {}
-    query = { 'query':{'bool':{'must_not':[
-        {'term':{'ops:Tracking_Meta/ops:archive_status':'staged'}}]}},
-              '_source':{'includes':['lidvid', key]},
-              'size':10000 }
+    query = {'query': {'bool': {'must_not': [
+        {'term': {'ops:Tracking_Meta/ops:archive_status': 'staged'}}]}},
+        '_source': {'includes': ['lidvid', key]},
+        'size': 10000}
     while more_data:
-        resp = requests.get (urllib.parse.urljoin (host.url, path),
-                             auth=(host.username, host.password),
-                             verify=host.verify, json=query)
+        resp = requests.get(urllib.parse.urljoin(host.url, path),
+                            auth=(host.username, host.password),
+                            verify=host.verify, json=query)
 
         if resp.status_code == 200:
             data = resp.json()
             path = '_search/scroll'
-            query = {'scroll':'10m','scroll_id':data['_scroll_id']}
-            provenance.update ({hit['_source']['lidvid']:hit['_source'].get(key, None) for hit in data['hits']['hits']})
+            query = {'scroll': '10m', 'scroll_id': data['_scroll_id']}
+            provenance.update({hit['_source']['lidvid']: hit['_source'].get(key, None) for hit in data['hits']['hits']})
             more_data = len(provenance) < data['hits']['total']['value']
         else:
             more_data = False
-            log.error ('Bad response code (%d): %s',
-                       resp.status_code, resp.reason)
+            log.error('Bad response code (%d): %s',
+                      resp.status_code, resp.reason)
             sys.exit(-50)
-        log.info ('   progress: %d of %d (%d%%)', len(provenance),
-                  data['hits']['total']['value'],
-                  int(round(len(provenance)/data['hits']['total']['value']*100)))
+        log.info('   progress: %d of %d (%d%%)', len(provenance),
+                 data['hits']['total']['value'],
+                 int(round(len(provenance) / data['hits']['total']['value'] * 100)))
         pass
 
     if 'scroll_id' in query:
         path = '_search/scroll/' + query['scroll_id']
-        requests.delete (urllib.parse.urljoin (host.url, path),
-                         auth=(host.username, host.password),
-                         verify=host.verify)
+        requests.delete(urllib.parse.urljoin(host.url, path),
+                        auth=(host.username, host.password),
+                        verify=host.verify)
         pass
-    log.info ('finished trolling')
+    log.info('finished trolling')
     return provenance
 
-def update_docs (host:HOST, history:{str:str}):
-    log.info ('Bulk update %d documents', len(history))
+
+def update_docs(host: HOST, history: {str: str}):
+    log.info('Bulk update %d documents', len(history))
     bulk = []
     cluster = [node + ":registry" for node in host.nodes]
     headers = {'Content-Type': 'application/x-ndjson'}
-    path = ','.join (['registry'] + cluster) + '/_bulk'
-    for lidvid,supersede in history.items():
-        bulk.append (json.dumps({'update':{'_id':lidvid}}))
-        bulk.append (json.dumps({'doc':{'ops:Provenance/ops:superseded_by':supersede}}))
+    path = ','.join(['registry'] + cluster) + '/_bulk'
+    for lidvid, supersede in history.items():
+        bulk.append(json.dumps({'update': {'_id': lidvid}}))
+        bulk.append(json.dumps({'doc': {'ops:Provenance/ops:superseded_by': supersede}}))
         pass
     bulk = '\n'.join(bulk) + '\n'
-    response = requests.put (urllib.parse.urljoin (host.url, path),
-                             auth=(host.username, host.password),
-                             data=bulk, headers=headers, verify=host.verify)
+    response = requests.put(urllib.parse.urljoin(host.url, path),
+                            auth=(host.username, host.password),
+                            data=bulk, headers=headers, verify=host.verify)
 
     if response.status_code != 200:
-        log.error ('Bulk bad response code (%d): %s',
-                   response.status_code, response.reason)
+        log.error('Bulk bad response code (%d): %s',
+                  response.status_code, response.reason)
     else:
         response = response.json()
         if response['errors']:
@@ -158,7 +170,9 @@ def update_docs (host:HOST, history:{str:str}):
                               str(item['error']))
                     pass
                 pass
-        else: log.info ('bulk update were successful')
+        else:
+            log.info('bulk update were successful')
     return
+
 
 if __name__ == '__main__': cli()

--- a/support/provenance.py
+++ b/support/provenance.py
@@ -4,7 +4,7 @@ import argparse
 import collections
 import json
 import logging
-from typing import Union
+from typing import Union, List
 
 log = logging.getLogger('provenance')
 import os
@@ -48,16 +48,24 @@ def configure_logging(filepath: Union[str, None], log_level: int):
     )
 
 
-def run(args: argparse.Namespace):  # TODO: break this out into individual function args
-    configure_logging(filepath=args.log_file, log_level=args.log_level)
+def run(
+        cluster_nodes: List[str],  # TODO: confirm type
+        base_url: str,
+        username: str,
+        password: str,
+        verify_host_certs: bool = False,
+        reset: bool = False,
+        log_filepath: Union[str, None] = None,
+        log_level: int = logging.INFO):
+
+    configure_logging(filepath=log_filepath, log_level=log_level)
 
     log.info('starting CLI processing')
 
-    host = HOST(args.cluster_nodes, args.password, args.base_URL, args.username,
-                args.verify)
+    host = HOST(cluster_nodes, password, base_url, username, verify_host_certs)
 
     provenance = trawl_registry(host)
-    updates = get_historic(provenance, args.reset)
+    updates = get_historic(provenance, reset)
 
     if updates:
         update_docs(host, updates)
@@ -199,4 +207,12 @@ if __name__ == '__main__':
                     help='verify the host certificates')
     args = ap.parse_args()
 
-    run(args)
+    run(
+        cluster_nodes=args.cluster_nodes,
+        base_url=args.base_URL,
+        username=args.username,
+        password=args.password,
+        verify_host_certs=args.verify,
+        reset=args.reset,
+        log_level=args.log_level,
+        log_filepath=args.log_file)

--- a/support/provenance.py
+++ b/support/provenance.py
@@ -56,7 +56,7 @@ def run(args: argparse.Namespace):  # TODO: break this out into individual funct
     host = HOST(args.cluster_nodes, args.password, args.base_URL, args.username,
                 args.verify)
 
-    provenance = troll_registry(host)
+    provenance = trawl_registry(host)
     updates = get_historic(provenance, args.reset)
 
     if updates:
@@ -92,8 +92,8 @@ def get_historic(provenance: {str: str}, reset: bool) -> {str: str}:  # TODO: po
     return history
 
 
-def troll_registry(host: HOST) -> {str: str}:  # TODO: populate comment and rename for clarity
-    log.info('start trolling')
+def trawl_registry(host: HOST) -> {str: str}:  # TODO: populate comment and rename for clarity
+    log.info('start trawling')
 
     cluster = [node + ":registry" for node in host.nodes]
     key = 'ops:Provenance/ops:superseded_by'
@@ -135,7 +135,7 @@ def troll_registry(host: HOST) -> {str: str}:  # TODO: populate comment and rena
                         verify=host.verify)
         pass
 
-    log.info('finished trolling')
+    log.info('finished trawling')
 
     return provenance
 

--- a/support/provenance.py
+++ b/support/provenance.py
@@ -134,19 +134,19 @@ def update_docs(host: HOST, history: {str: str}):
     """Write provenance history updates to documents in db"""
     log.info('Bulk update %d documents', len(history))
 
-    bulk = []  # TODO: name descriptively
+    bulk_updates = []
     cluster = [node + ":registry" for node in host.nodes]
     headers = {'Content-Type': 'application/x-ndjson'}
     path = ','.join(['registry'] + cluster) + '/_bulk'
 
     for lidvid, supersede in history.items():
-        bulk.append(json.dumps({'update': {'_id': lidvid}}))
-        bulk.append(json.dumps({'doc': {'ops:Provenance/ops:superseded_by': supersede}}))
+        bulk_updates.append(json.dumps({'update': {'_id': lidvid}}))
+        bulk_updates.append(json.dumps({'doc': {'ops:Provenance/ops:superseded_by': supersede}}))
 
-    bulk = '\n'.join(bulk) + '\n'
+    bulk_data = '\n'.join(bulk_updates) + '\n'
     response = requests.put(urllib.parse.urljoin(host.url, path),
                             auth=(host.username, host.password),
-                            data=bulk, headers=headers, verify=host.verify)
+                            data=bulk_data, headers=headers, verify=host.verify)
 
     if response.status_code != 200:
         log.error('Bulk bad response code (%d): %s',

--- a/support/provenance.py
+++ b/support/provenance.py
@@ -3,7 +3,8 @@
 import argparse
 import collections
 import json
-import logging;
+import logging
+from typing import Union
 
 log = logging.getLogger('provenance')
 import os
@@ -30,9 +31,25 @@ def _vid_as_tuple_of_int(lidvid: str):
     return (int(M), int(m))
 
 
+def configure_logging(filepath: Union[str, None], log_level: int):
+    logging.root.handlers = []
+    handlers = [
+        logging.StreamHandler()
+    ]
+
+    if filepath:
+        handlers.append(logging.FileHandler(filepath))
+
+    logging.basicConfig(
+        level=log_level,
+        format='%(asctime)s::%(levelname)s::%(message)s',
+        handlers=handlers
+    )
+
+
 def run(args: argparse.Namespace):
-    logging.basicConfig(filename=args.log_file, level=args.log_level,
-                        format='%(asctime)s::%(levelname)s::%(message)s')
+    configure_logging(filepath=args.log_file, log_level=args.log_level)
+
     log.info('starting CLI processing')
     host = HOST(args.cluster_nodes, args.password, args.base_URL, args.username,
                 args.verify)
@@ -162,8 +179,8 @@ if __name__ == '__main__':
     ap.add_argument('-b', '--base-URL', required=True, type=str)
     ap.add_argument('-c', '--cluster-nodes', default=[], nargs='*',
                     help='names of opensearch cluster nodes that will be parsed by opensearch')
-    ap.add_argument('-l', '--log-file', default='/dev/stdout', required=False,
-                    help='file to write the log messages [%(default)s]')
+    ap.add_argument('-l', '--log-file', default=None, required=False,
+                    help='file to write the log messages')
     ap.add_argument('-L', '--log-level', default='ERROR', required=False,
                     type=_log_level,
                     help='Python logging level as an int or string like INFO for logging.INFO [%(default)s]')


### PR DESCRIPTION
## 🗒️ Summary
This started out as an attempt to understand the script and figure out why it ostensibly wasn't working on my local dev instance (it was - the API version I was using was old).

Cliffnotes:
- argument parsing is moved to the main block to allow `run()` to be called from other contexts
- tweaked logging and changed default level to INFO (otherwise, a successful run yields no output, which is confusing)
- simplified some status checks that were just throwing on non-200
- renamed some labels for clarity 
- removed extraneous no-op statements
- Python-consistent styling (whitespace, line-breaks).  I won't say PEP because it wasn't a comprehensive lint.

I've left the commits granular in case some of these changes aren't desirable (kick them back to me and I'll fix)