### PR TITLE
Add classes for LID/VID/LIDVID and fix #224

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/model/LidVidUtils.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/LidVidUtils.java
@@ -34,14 +34,21 @@ public class LidVidUtils
 {
 	private static final String LIDVID_SEPARATOR = "::";
 	private static final Logger log = LoggerFactory.getLogger(LidVidUtils.class);
-	
-	public static String extractLidFromLidVid(String identifier)
+
+	public static String parseLid(String lidOrLidVid)
     {
-        if (identifier == null) return null;
-        else return identifier.contains(LIDVID_SEPARATOR)?identifier.substring(0, identifier.indexOf(LIDVID_SEPARATOR)):identifier;
+        if (lidOrLidVid == null) {
+			return null;
+		}
+
+		if (lidOrLidVid.contains(LIDVID_SEPARATOR)) {
+			return lidOrLidVid.substring(0, lidOrLidVid.indexOf(LIDVID_SEPARATOR));
+		}
+
+		return lidOrLidVid;
     }
-    
-    
+
+
     /**
      * Get latest versions of LIDs
      */
@@ -51,7 +58,7 @@ public class LidVidUtils
             Collection<String> lids) throws IOException,LidVidNotFoundException
     {
     	List<String> lidvids = new ArrayList<String>();
-    	
+
     	for (String lid : lids)
     	{
     		try { lidvids.add (LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext, lid)); }
@@ -61,16 +68,16 @@ public class LidVidUtils
 
     	return lidvids;
     }
-    
+
     public static String getLatestLidVidByLid(
     		ControlContext ctlContext,
     		RequestBuildContext reqContext,
-            String lid) throws IOException,LidVidNotFoundException
+            String lidOrLidVid) throws IOException,LidVidNotFoundException
     {
-    	lid = LidVidUtils.extractLidFromLidVid(lid);
+    	String lid = LidVidUtils.parseLid(lidOrLidVid);
     	SearchRequest searchRequest = new SearchRequestFactory(RequestConstructionContextFactory.given("lid", lid, true), ctlContext.getConnection())
     			.build(RequestBuildContextFactory.given(true, "lidvid", reqContext.getPresetCriteria()), ctlContext.getConnection().getRegistryIndex());
-    	SearchResponse searchResponse = ctlContext.getConnection().getRestHighLevelClient().search(searchRequest, 
+    	SearchResponse searchResponse = ctlContext.getConnection().getRestHighLevelClient().search(searchRequest,
     			RequestOptions.DEFAULT);
 
     	if (searchResponse != null)
@@ -80,7 +87,7 @@ public class LidVidUtils
     		for (SearchHit searchHit : searchResponse.getHits())
     		{
     			lidvid = (String)searchHit.getSourceAsMap().get("lidvid");;
-    			lidvids.add(lidvid);                
+    			lidvids.add(lidvid);
     		}
     		Collections.sort(lidvids);
 
@@ -89,7 +96,7 @@ public class LidVidUtils
     	}
     	throw new LidVidNotFoundException(lid);
     }
-    
+
     public static List<String> getAllLidVidsByLids(
     		ControlContext ctlContext,
     		RequestBuildContext reqContext,
@@ -114,10 +121,10 @@ public class LidVidUtils
     		RequestBuildContext reqContext) throws IOException, LidVidNotFoundException
     {
     	String result = identifier;
-    	
+
     	if (0 < identifier.length())
     	{
-    		String lid = LidVidUtils.extractLidFromLidVid(identifier);
+    		String lid = LidVidUtils.parseLid(identifier);
     		/* YUCK! This should use polymorphism in ProductVersionSelector not a switch statement */
     		switch (scope)
     		{
@@ -128,7 +135,7 @@ public class LidVidUtils
     			result = LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext, lid);
     			break;
     		case TYPED:
-    			result = lid.equals(identifier) ? LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext, lid) : identifier; 
+    			result = lid.equals(identifier) ? LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext, lid) : identifier;
     			break;
     		case ORIGINAL: throw new LidVidNotFoundException("ProductVersionSelector.ORIGINAL not supported");
     		default: throw new LidVidNotFoundException("Unknown and unhandles ProductVersionSelector value.");
@@ -141,12 +148,12 @@ public class LidVidUtils
 			throws IOException, LidVidMismatchException, LidVidNotFoundException, UnknownGroupNameException
 	{
 		ReferencingLogicTransmuter expected_rlt = ReferencingLogicTransmuter.getBySwaggerGroup(user.getGroup());
-			
+
 		if (expected_rlt != ReferencingLogicTransmuter.Any)
 		{
 			String actual_group = QuickSearch.getValue(control.getConnection(), false, user.getLidVid(), "product_class");
 			ReferencingLogicTransmuter actual_rlt = ReferencingLogicTransmuter.getByProductClass(actual_group);
-			
+
 			if (actual_rlt != expected_rlt)
 				throw new LidVidMismatchException(user.getLidVid(), user.getGroup(), actual_group);
 		}

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/PdsLid.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/PdsLid.java
@@ -1,0 +1,36 @@
+package gov.nasa.pds.api.registry.model;
+
+public class PdsLid {
+    private String value;
+
+    public PdsLid(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+    @Override
+    public String toString() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof PdsLid)) {
+            return false;
+        }
+
+        PdsLid otherAsLid = (PdsLid) other;
+        return this.value.equals(otherAsLid.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return this.value.hashCode();
+    }
+}

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/PdsLidVid.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/PdsLidVid.java
@@ -1,0 +1,71 @@
+package gov.nasa.pds.api.registry.model;
+
+public class PdsLidVid implements Comparable<PdsLidVid>{
+    private final PdsLid lid;
+    private final PdsVid vid;
+
+    public PdsLid getLid() {
+        return lid;
+    }
+
+    public PdsVid getVid() {
+        return vid;
+    }
+
+    public PdsLidVid(PdsLid lid, PdsVid vid) {
+        this.lid = lid;
+        this.vid = vid;
+    }
+
+    public static PdsLidVid fromString(String lidVidString) {
+        String[] chunks = lidVidString.split("::");
+
+        if (chunks.length != 2) {
+            String errMsg = String.format("Provided value '%s' is not a valid LIDVID", lidVidString);
+            throw new IllegalArgumentException(errMsg);
+        }
+
+        PdsLid lid = new PdsLid(chunks[0]);
+        PdsVid vid = PdsVid.fromString(chunks[1]);
+
+        return new PdsLidVid(lid, vid);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.toString().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof PdsLidVid)) {
+            return false;
+        }
+
+        PdsLidVid otherAsLidVid = (PdsLidVid) other;
+        return this.lid.equals(otherAsLidVid.lid) && this.vid.equals(otherAsLidVid.vid);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s::%s", this.lid, this.vid);
+    }
+
+    @Override
+    public int compareTo(PdsLidVid other) {
+        if (this.equals(other)) {
+            return 0;
+        }
+
+        if (!this.lid.equals(other.lid)) {
+            String errMsg = String.format("Comparison is only defined between LIDVIDs with identical LIDs (got '%s', '%s')", this.lid, other.lid);
+            throw new IllegalArgumentException(errMsg);
+        }
+
+        return this.vid.compareTo(other.vid);
+    }
+}

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/PdsVid.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/PdsVid.java
@@ -1,0 +1,80 @@
+package gov.nasa.pds.api.registry.model;
+
+public class PdsVid implements Comparable<PdsVid> {
+    private final int majorVersion;
+    private final int minorVersion;
+
+    public PdsVid(int majorVersion, int minorVersion) {
+        if (majorVersion < 1) {
+            String errMsg = String.format("majorVersion must be 1 or higher (got '%d'))", majorVersion);
+            throw new IllegalArgumentException(errMsg);
+        }
+
+        if (minorVersion < 0) {
+            String errMsg = String.format("minorVersion must be 0 or higher (got '%d'))", minorVersion);
+            throw new IllegalArgumentException(errMsg);
+        }
+
+        this.majorVersion = majorVersion;
+        this.minorVersion = minorVersion;
+    }
+
+    public static PdsVid fromString(String vidString) {
+        String[] versionChunks = vidString.split("\\.");
+
+        if (versionChunks.length != 2) {
+            String errMsg = String.format("Provided value '%s' is not a valid VID", vidString);
+            throw new IllegalArgumentException(errMsg);
+        }
+
+        int majorVersion = Integer.parseInt(versionChunks[0]);
+        int minorVersion = Integer.parseInt(versionChunks[1]);
+
+        return new PdsVid(majorVersion, minorVersion);
+    }
+
+    public int getMajorVersion() {
+        return majorVersion;
+    }
+
+    public int getMinorVersion() {
+        return minorVersion;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%d.%d", majorVersion, minorVersion);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof PdsVid)) {
+            return false;
+        }
+
+        PdsVid otherAsVid = (PdsVid) other;
+        return this.majorVersion == otherAsVid.getMajorVersion() && this.minorVersion == otherAsVid.getMinorVersion();
+    }
+
+    @Override
+    public int hashCode() {
+        return this.toString().hashCode();
+    }
+
+    @Override
+    public int compareTo(PdsVid o) {
+        if (this.equals(o)) {
+            return 0;
+        }
+
+        if (this.majorVersion == o.getMajorVersion()) {
+            return Integer.compare(this.minorVersion, o.getMinorVersion());
+        } else {
+            return Integer.compare(this.majorVersion, o.getMajorVersion());
+        }
+    }
+}

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
@@ -42,7 +42,7 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic
     	preset.put("product_class", Arrays.asList("Product_Collection"));
     	return GroupConstraintImpl.buildAll(preset);
     }
-	
+
     static Pagination<String> children (ControlContext control, ProductVersionSelector selection, LidvidsContext uid)
     		throws IOException, LidVidNotFoundException
     {
@@ -77,7 +77,7 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic
         { productLidvids.add(kvp.get("product_lidvid")); }
         return productLidvids;
     }
-    
+
     static Pagination<String> parents (ControlContext control, ProductVersionSelector selection,  LidvidsContext uid)
     		throws IOException, LidVidNotFoundException
     {
@@ -85,11 +85,11 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic
     		                              "ref_lidvid_collection", "ref_lidvid_collection_secondary");
     	List<String> sortedLids;
     	Set<String> lids = new HashSet<String>();
-    	String lid = LidVidUtils.extractLidFromLidVid(uid.getLidVid());
+    	String lid = LidVidUtils.parseLid(uid.getLidVid());
         PaginationLidvidBuilder bundleLidvids = new PaginationLidvidBuilder(uid);
 
         log.info("Find parents of a colletion -- both all and latest");
-        log.info("Find parents of collenction: " + uid.getLidVid() + "  --- " + LidVidUtils.extractLidFromLidVid(uid.getLidVid()));
+        log.info("Find parents of collenction: " + uid.getLidVid() + "  --- " + LidVidUtils.parseLid(uid.getLidVid()));
         for (String key : keys)
         {
         	for (final Map<String,Object> kvp : new HitIterator(control.getConnection().getRestHighLevelClient(),
@@ -102,10 +102,10 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic
         }
         sortedLids = new ArrayList<String>(lids);
         Collections.sort(sortedLids);
-        
+
         if (selection == ProductVersionSelector.ALL)
         	bundleLidvids.addAll (LidVidUtils.getAllLidVidsByLids(control, RequestBuildContextFactory.empty(), sortedLids));
-        else 
+        else
         	bundleLidvids.addAll (LidVidUtils.getLatestLidVidsByLids(control, RequestBuildContextFactory.empty(), sortedLids));
 
         return bundleLidvids;
@@ -124,7 +124,7 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic
 	@Override
 	public RequestAndResponseContext memberOf(ControlContext context, UserContext input, boolean twoSteps)
 			throws ApplicationTypeException, IOException, LidVidNotFoundException, MembershipException,
-			UnknownGroupNameException 
+			UnknownGroupNameException
 	{
 		if (twoSteps) throw new MembershipException(input.getIdentifier(), "member-of/member-of", "collections");
 		return RequestAndResponseContext.buildRequestAndResponseContext

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/SearchRequestFactory.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/SearchRequestFactory.java
@@ -22,7 +22,7 @@ public class SearchRequestFactory
     private static final Logger log = LoggerFactory.getLogger(SearchRequestFactory.class);
     final private BoolQueryBuilder base = QueryBuilders.boolQuery();
     final private ConnectionContext regContext;
-    
+
     public SearchRequestFactory(RequestConstructionContext context, ConnectionContext registry)
     {
     	this.regContext = registry;
@@ -32,7 +32,7 @@ public class SearchRequestFactory
     		for (Map.Entry<String, List<String>> entry: context.getKeyValuePairs().entrySet())
     		{
     			if (context.isTerm())
-    			{ 
+    			{
     				if (entry.getValue().size() == 1)
     				{ this.base.must(QueryBuilders.termQuery(entry.getKey(), entry.getValue().get(0))); }
     				else
@@ -62,7 +62,7 @@ public class SearchRequestFactory
 
     	if (!context.getLIDVID().isBlank())
     	{
-    		String key = LidVidUtils.extractLidFromLidVid(context.getLIDVID()).equals(context.getLIDVID()) ? "lid" : "lidvid";
+    		String key = LidVidUtils.parseLid(context.getLIDVID()).equals(context.getLIDVID()) ? "lid" : "lidvid";
 
     		this.base.must(QueryBuilders.termQuery(key, context.getLIDVID())); // term is exact match which lidvid look should be
     	}
@@ -81,7 +81,7 @@ public class SearchRequestFactory
 
     	return exclude;
     }
-    
+
     public SearchRequest build (RequestBuildContext context, String index)
     {
     	if (this.regContext.getRegistryIndex().equals(index))

--- a/service/src/test/java/gov/nasa/pds/api/registry/model/PdsLidTest.java
+++ b/service/src/test/java/gov/nasa/pds/api/registry/model/PdsLidTest.java
@@ -1,0 +1,19 @@
+package gov.nasa.pds.api.registry.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PdsLidTest {
+    @Test
+    public void testEquality() {
+        PdsLid baseLid = new PdsLid("urn:nasa:pds:epoxi");
+        PdsLid equalLid = new PdsLid("urn:nasa:pds:epoxi");
+        PdsLid unequalLid = new PdsLid("urn:nasa:pds:notEpoxi");
+
+        Assert.assertEquals(baseLid, equalLid);
+        Assert.assertEquals(baseLid.hashCode(), equalLid.hashCode());
+
+        Assert.assertNotEquals(baseLid, unequalLid);
+        Assert.assertNotEquals(baseLid.hashCode(), unequalLid.hashCode());
+    }
+}

--- a/service/src/test/java/gov/nasa/pds/api/registry/model/PdsLidVidTest.java
+++ b/service/src/test/java/gov/nasa/pds/api/registry/model/PdsLidVidTest.java
@@ -1,0 +1,60 @@
+package gov.nasa.pds.api.registry.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class PdsLidVidTest {
+
+    @Test
+    public void testValidInstantiations() {
+        PdsLidVid lidVid = PdsLidVid.fromString("urn:nasa:pds:epoxi::1.0");
+    }
+
+    @Test
+    public void testInvalidInstantiations() {
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            PdsLidVid.fromString("some:lid:without:vid");
+        });
+    }
+
+
+    @Test
+    public void testEquality() {
+        PdsLidVid base = PdsLidVid.fromString("urn:nasa:pds:epoxi::1.0");
+        PdsLidVid equal = PdsLidVid.fromString("urn:nasa:pds:epoxi::1.0");
+        PdsLidVid differentLid = PdsLidVid.fromString("urn:nasa:pds:notEpoxi::1.0");
+        PdsLidVid differentVid = PdsLidVid.fromString("urn:nasa:pds:epoxi::1.1");
+
+        Assert.assertEquals(base, equal);
+        Assert.assertEquals(base.hashCode(), equal.hashCode());
+
+        Assert.assertNotEquals(base, differentLid);
+        Assert.assertNotEquals(base.hashCode(), differentLid.hashCode());
+
+        Assert.assertNotEquals(base, differentVid);
+        Assert.assertNotEquals(base.hashCode(), differentVid.hashCode());
+    }
+
+    @Test
+    public void testComparison() {
+        PdsLidVid first = PdsLidVid.fromString("something::1.0");
+        PdsLidVid second = PdsLidVid.fromString("something::2.0");
+        PdsLidVid third = PdsLidVid.fromString("something::3.0");
+        PdsLidVid mismatched = PdsLidVid.fromString("somethingElse::4.0");
+
+        List<PdsLidVid> valid = Arrays.asList(third, first, second);
+        Collections.sort(valid);
+        Assert.assertArrayEquals(new PdsLidVid[]{first, second, third}, valid.toArray());
+
+        List<PdsLidVid> invalid = Arrays.asList(third, first, second, mismatched);
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            Collections.sort(invalid);
+        });
+    }
+}

--- a/service/src/test/java/gov/nasa/pds/api/registry/model/PdsVidTest.java
+++ b/service/src/test/java/gov/nasa/pds/api/registry/model/PdsVidTest.java
@@ -1,0 +1,64 @@
+package gov.nasa.pds.api.registry.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PdsVidTest {
+
+    @Test
+    public void testValidInstantiations() {
+        PdsVid.fromString("1.0");
+    }
+
+    @Test
+    public void testInvalidInstantiations() {
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            PdsVid.fromString("0.1");
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            PdsVid.fromString("1.-1");
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            PdsVid.fromString("1.0.0");
+        });
+    }
+
+    @Test
+    public void testEquality() {
+        PdsVid base = new PdsVid(1, 0);
+        PdsVid equal = new PdsVid(1, 0);
+        PdsVid differentMajorVersion = new PdsVid(2, 0);
+        PdsVid differentMinorVersion = new PdsVid(1, 1);
+
+        Assert.assertEquals(base, equal);
+        Assert.assertEquals(base.hashCode(), equal.hashCode());
+
+        Assert.assertNotEquals(base, differentMajorVersion);
+        Assert.assertNotEquals(base.hashCode(), differentMajorVersion.hashCode());
+
+        Assert.assertNotEquals(base, differentMinorVersion);
+        Assert.assertNotEquals(base.hashCode(), differentMinorVersion.hashCode());
+    }
+
+    @Test
+    public void testComparison() {
+        PdsVid base = new PdsVid(5, 5);
+        PdsVid equal = new PdsVid(5, 5);
+        PdsVid higherMajorVersion = new PdsVid(10, 5);
+        PdsVid lowerMajorVersion = new PdsVid(1, 5);
+        PdsVid higherMinorVersion = new PdsVid(5, 10);
+        PdsVid lowerMinorVersion = new PdsVid(5, 1);
+        PdsVid higherMajorLowerMinor = new PdsVid(10, 1);
+        PdsVid lowerMajorHigherMinor = new PdsVid(1, 10);
+
+        Assert.assertEquals(0, base.compareTo(equal));
+        Assert.assertTrue(base.compareTo(higherMajorVersion) < 0);
+        Assert.assertTrue(base.compareTo(lowerMajorVersion) > 0);
+        Assert.assertTrue(base.compareTo(higherMinorVersion) < 0);
+        Assert.assertTrue(base.compareTo(lowerMinorVersion) > 0);
+        Assert.assertTrue(base.compareTo(higherMajorLowerMinor) < 0);
+        Assert.assertTrue(base.compareTo(lowerMajorHigherMinor) > 0);
+    }
+}


### PR DESCRIPTION
## 🗒️ Summary
Introduces LID/VID/LIDVID as first-class objects, including comparison operations.

## ⚙️ Test Data and/or Report
Unit tests added for new classes, manually-tested test cases for #224 

## ♻️ Related Issues
fixes #224
causes #234 as a side-effect of fixing #224 (but I'll get to that)


