### PR TITLE
Add additional lidvid classes

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/RequestBuildContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/RequestBuildContext.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public interface RequestBuildContext
 {
-	public boolean justLatest(); // return just the latest LIDVIDs
+	public boolean justLatest(); // return just the latest LIDVIDs. return false if request is made for a specific version
 	public List<String> getFields(); // must not return null but an empty list
 	public GroupConstraint getPresetCriteria(); // must not return null but an empty list
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/RequestConstructionContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/RequestConstructionContext.java
@@ -1,5 +1,7 @@
 package gov.nasa.pds.api.registry;
 
+import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
+
 import java.util.List;
 import java.util.Map;
 
@@ -7,7 +9,8 @@ public interface RequestConstructionContext
 {
 	public List<String> getKeywords(); // must not return null but an empty list
 	public Map<String, List<String>> getKeyValuePairs(); // must not return null but an empty map
-	public String getLIDVID(); // must not return null but an empty string
+	public PdsProductIdentifier getProductIdentifier();
+	public String getProductIdentifierString(); // must not return null but an empty string
 	public String getQueryString(); // must not return null but an empty string
 	public boolean isTerm(); // if true, then use QueryBuilders.termQuery otherwise use QueryBuilders.matchQuery
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
@@ -97,7 +97,7 @@ public class SwaggerJavaTransmuter extends SwaggerJavaDeprecatedTransmuter imple
 		long begin = System.currentTimeMillis();
         try
         {
-        	parameters.setAccept(this.request.getHeader("Accept")).setLidVid(this);
+        	parameters.setAccept(this.request.getHeader("Accept")).setProductIdentifier(this);
         	if (parameters.getVerifyClassAndId()) LidVidUtils.verify (this, parameters);
         	return handler.transmute(this, parameters);
         }

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
@@ -32,18 +32,18 @@ import gov.nasa.pds.api.registry.exceptions.MembershipException;
 import gov.nasa.pds.api.registry.exceptions.NothingFoundException;
 import gov.nasa.pds.api.registry.exceptions.UnknownGroupNameException;
 import gov.nasa.pds.api.registry.model.ErrorFactory;
-import gov.nasa.pds.api.registry.model.LidVidUtils;
+import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
 
 @Controller
 public class SwaggerJavaTransmuter extends SwaggerJavaDeprecatedTransmuter implements ControlContext, BundlesApi, CollectionsApi, ClassesApi, ProductsApi
 {
-    private static final Logger log = LoggerFactory.getLogger(SwaggerJavaTransmuter.class);  
+    private static final Logger log = LoggerFactory.getLogger(SwaggerJavaTransmuter.class);
     private final ObjectMapper objectMapper;
-    private final HttpServletRequest request;   
-    
+    private final HttpServletRequest request;
+
     @Value("${server.contextPath}")
     protected String contextPath;
-    
+
     @Autowired
     protected HttpServletRequest context;
 
@@ -68,15 +68,15 @@ public class SwaggerJavaTransmuter extends SwaggerJavaDeprecatedTransmuter imple
             if (this.proxyRunsOnDefaultPort())
             {
                 baseURL = new URL(this.context.getScheme(), this.context.getServerName(), this.contextPath);
-            } 
+            }
             else
             {
                 baseURL = new URL(this.context.getScheme(), this.context.getServerName(), this.context.getServerPort(), this.contextPath);
             }
-            
+
             log.debug("baseUrl is " + baseURL.toString());
             return baseURL;
-            
+
         }
 		catch (MalformedURLException e)
 		{
@@ -106,7 +106,7 @@ public class SwaggerJavaTransmuter extends SwaggerJavaDeprecatedTransmuter imple
         	log.error("Application type not implemented", e);
         	return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_ACCEPTABLE);
         }
-        catch (IOException e) 
+        catch (IOException e)
         {
             log.error("Couldn't get or serialize response for content type " + this.request.getHeader("Accept"), e);
             return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.INTERNAL_SERVER_ERROR);
@@ -142,12 +142,12 @@ public class SwaggerJavaTransmuter extends SwaggerJavaDeprecatedTransmuter imple
 
 	private boolean proxyRunsOnDefaultPort()
 	{
-        return (("https".equals(this.context.getScheme()) && (this.context.getServerPort() == 443)) 
+        return (("https".equals(this.context.getScheme()) && (this.context.getServerPort() == 443))
                 || ("http".equals(this.context.getScheme())  && (this.context.getServerPort() == 80)));
     }
 
 	@Override
-	public ResponseEntity<Object> bundleList(@Valid List<String> fields, @Valid List<String> keywords, 
+	public ResponseEntity<Object> bundleList(@Valid List<String> fields, @Valid List<String> keywords,
 			@Min(0) @Valid Integer limit, @Valid String q, @Valid List<String> sort,
 			@Min(0) @Valid Integer start) {
 		// TODO Auto-generated method stub
@@ -202,7 +202,7 @@ public class SwaggerJavaTransmuter extends SwaggerJavaDeprecatedTransmuter imple
 	}
 
 	@Override
-	public ResponseEntity<Object> collectionList(@Valid List<String> fields, @Valid List<String> keywords, 
+	public ResponseEntity<Object> collectionList(@Valid List<String> fields, @Valid List<String> keywords,
 			@Min(0) @Valid Integer limit, @Valid String q, @Valid List<String> sort,
 			@Min(0) @Valid Integer start) {
 		// TODO Auto-generated method stub
@@ -257,7 +257,7 @@ public class SwaggerJavaTransmuter extends SwaggerJavaDeprecatedTransmuter imple
 	}
 
 	@Override
-	public ResponseEntity<Object> productList(@Valid List<String> fields, @Valid List<String> keywords, 
+	public ResponseEntity<Object> productList(@Valid List<String> fields, @Valid List<String> keywords,
 			@Min(0) @Valid Integer limit, @Valid String q, @Valid List<String> sort,
 			@Min(0) @Valid Integer start) {
 		// TODO Auto-generated method stub

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
@@ -121,7 +121,7 @@ class URIParameters implements UserContext
 	}
 	public URIParameters setLidVid(ControlContext control) throws IOException, LidVidNotFoundException
 	{
-		this.lidvid = LidVidUtils.resolve(this.getIdentifier(), ProductVersionSelector.TYPED,
+		this.lidvid = LidVidUtils.resolve(this.getIdentifier(), ProductVersionSelector.SPECIFIC,
 				control, RequestBuildContextFactory.empty());
 		return this;
 	}

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
@@ -7,14 +7,14 @@ import java.util.List;
 import gov.nasa.pds.api.registry.ControlContext;
 import gov.nasa.pds.api.registry.UserContext;
 import gov.nasa.pds.api.registry.exceptions.LidVidNotFoundException;
-import gov.nasa.pds.api.registry.model.LidVidUtils;
+import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
 import gov.nasa.pds.api.registry.model.ProductVersionSelector;
 import gov.nasa.pds.api.registry.search.RequestBuildContextFactory;
 
 /*
  * Maybe not the most obvious properties class or bean or whatever name but
  * here are some things that are being done and must be maintained
- * 
+ *
  * 1. If the set value is null, then leave the default value in place.
  *    The reason for ignoring null, is that 100 different places do not have
  *    to test for null then do the default thing. The default thing when not
@@ -31,7 +31,7 @@ import gov.nasa.pds.api.registry.search.RequestBuildContextFactory;
 class URIParameters implements UserContext
 {
 	private static final int SUMMARY_SAMPLE_SIZE = 100;
-	
+
 	private boolean verifyClassAndId = false;
 	private String accept = "application/json";
 	private List<String> fields = new ArrayList<String>();
@@ -102,7 +102,7 @@ class URIParameters implements UserContext
 	}
 	public URIParameters setLimit(Integer limit)
 	{
-		/* 
+		/*
 		 * Note: Not too happy w/ having to put behavioral logic in a utility/container class, but
 		 * there are just way too many places where this information is necessary and rather than
 		 * duplicate it everywhere, this is the best place, for now, as it is the common object

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
@@ -9,6 +9,7 @@ import gov.nasa.pds.api.registry.UserContext;
 import gov.nasa.pds.api.registry.exceptions.LidVidNotFoundException;
 import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
 import gov.nasa.pds.api.registry.model.ProductVersionSelector;
+import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 import gov.nasa.pds.api.registry.search.RequestBuildContextFactory;
 
 /*
@@ -38,7 +39,7 @@ class URIParameters implements UserContext
 	private String group = "";
 	private String identifier = "";
 	private List<String> keywords = new ArrayList<String>();
-	private String lidvid = "";
+	private PdsProductIdentifier productIdentifier = null;
 	private Integer limit = Integer.valueOf(0);
 	private boolean summaryOnly = true;
 	private String query = "";
@@ -60,7 +61,7 @@ class URIParameters implements UserContext
 	@Override
 	public Integer getLimit() { return limit; }
 	@Override
-	public String getLidVid() { return lidvid; }
+	public String getLidVid() { return productIdentifier != null ? productIdentifier.toString() : ""; }
 	@Override
 	public String getQuery() { return query; }
 	@Override
@@ -119,9 +120,9 @@ class URIParameters implements UserContext
 		}
 		return this;
 	}
-	public URIParameters setLidVid(ControlContext control) throws IOException, LidVidNotFoundException
+	public URIParameters setProductIdentifier(ControlContext control) throws IOException, LidVidNotFoundException
 	{
-		this.lidvid = LidVidUtils.resolve(this.getIdentifier(), ProductVersionSelector.SPECIFIC,
+		this.productIdentifier = LidVidUtils.resolve(this.getIdentifier(), ProductVersionSelector.SPECIFIC,
 				control, RequestBuildContextFactory.empty());
 		return this;
 	}

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/ProductVersionSelector.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/ProductVersionSelector.java
@@ -23,7 +23,7 @@ public enum ProductVersionSelector
      */
     LATEST,
     /**
-     * What the user typed but latest if a LID
+     * A specified version of a product
      */
-    TYPED
+    SPECIFIC
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicAny.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicAny.java
@@ -32,7 +32,7 @@ class RefLogicAny implements ReferencingLogic
 	{
 		return ReferencingLogicTransmuter.getByProductClass(
 				QuickSearch.getValue(context.getConnection(), input.getSelector() == ProductVersionSelector.LATEST,
-			             LidVidUtils.resolve(input.getIdentifier(), ProductVersionSelector.TYPED, context, RequestBuildContextFactory.empty()),
+			             LidVidUtils.resolve(input.getIdentifier(), ProductVersionSelector.SPECIFIC, context, RequestBuildContextFactory.empty()),
 			             "product_class"));
 	}
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicAny.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicAny.java
@@ -12,6 +12,7 @@ import gov.nasa.pds.api.registry.exceptions.ApplicationTypeException;
 import gov.nasa.pds.api.registry.exceptions.LidVidNotFoundException;
 import gov.nasa.pds.api.registry.exceptions.MembershipException;
 import gov.nasa.pds.api.registry.exceptions.UnknownGroupNameException;
+import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
 import gov.nasa.pds.api.registry.search.QuickSearch;
 import gov.nasa.pds.api.registry.search.RequestBuildContextFactory;
 import gov.nasa.pds.api.registry.util.GroupConstraintImpl;
@@ -41,7 +42,7 @@ class RefLogicAny implements ReferencingLogic
 		// find all of the given group that reference the specified ID
 		ReferencingLogicTransmuter groupType = ReferencingLogicTransmuter.getBySwaggerGroup(input.getGroup());
 		ReferencingLogicTransmuter idType = this.resolveID(context, input);
-		
+
 		if (idType == ReferencingLogicTransmuter.Bundle && groupType == ReferencingLogicTransmuter.Collection)
 			return RequestAndResponseContext.buildRequestAndResponseContext
 					(context, input, RefLogicBundle.children(context, input.getSelector(), input));

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicAny.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicAny.java
@@ -13,6 +13,7 @@ import gov.nasa.pds.api.registry.exceptions.LidVidNotFoundException;
 import gov.nasa.pds.api.registry.exceptions.MembershipException;
 import gov.nasa.pds.api.registry.exceptions.UnknownGroupNameException;
 import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
+import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 import gov.nasa.pds.api.registry.search.QuickSearch;
 import gov.nasa.pds.api.registry.search.RequestBuildContextFactory;
 import gov.nasa.pds.api.registry.util.GroupConstraintImpl;
@@ -30,10 +31,10 @@ class RefLogicAny implements ReferencingLogic
 	private ReferencingLogicTransmuter resolveID (ControlContext context, UserContext input)
 			throws IOException, LidVidNotFoundException, UnknownGroupNameException
 	{
+		PdsProductIdentifier productIdentifier = LidVidUtils.resolve(input.getIdentifier(), ProductVersionSelector.SPECIFIC, context, RequestBuildContextFactory.empty());
 		return ReferencingLogicTransmuter.getByProductClass(
 				QuickSearch.getValue(context.getConnection(), input.getSelector() == ProductVersionSelector.LATEST,
-			             LidVidUtils.resolve(input.getIdentifier(), ProductVersionSelector.SPECIFIC, context, RequestBuildContextFactory.empty()),
-			             "product_class"));
+			             productIdentifier != null ? productIdentifier.toString() : "", "product_class"));
 	}
 
 	private RequestAndResponseContext search(ControlContext context, UserContext input, boolean isIdToGroup)

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.search.SearchHit;
@@ -33,9 +34,9 @@ import gov.nasa.pds.api.registry.search.SearchRequestFactory;
 import gov.nasa.pds.api.registry.util.GroupConstraintImpl;
 
 /**
- * Bundle Data Access Object (DAO). 
+ * Bundle Data Access Object (DAO).
  * Provides methods to get bundle information from opensearch.
- * 
+ *
  * @author karpenko
  */
 @Immutable
@@ -48,7 +49,7 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic
     {
     	log.info("Find children of a bundle");
     	return selection == ProductVersionSelector.ALL ?
-    			getAllBundleCollectionLidVids(uid, control) : 
+    			getAllBundleCollectionLidVids(uid, control) :
     			getBundleCollectionLidVids(uid, control);
     }
 
@@ -67,7 +68,7 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic
         // Get bundle by lidvid.
         SearchRequest request = new SearchRequestFactory(RequestConstructionContextFactory.given(idContext.getLidVid()), ctlContext.getConnection())
         		.build(RequestBuildContextFactory.given(false, fields, ReferencingLogicTransmuter.Bundle.impl().constraints()), ctlContext.getConnection().getRegistryIndex());
-        
+
         // Call opensearch
         SearchHit hit;
         SearchHits hits = ctlContext.getConnection().getRestHighLevelClient().search(request, RequestOptions.DEFAULT).getHits();
@@ -84,7 +85,7 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic
 
         ids.addAll(lidvids.convert(fieldMap.get("ref_lid_collection")));
         ids.addAll(lidvids.convert(fieldMap.get("ref_lid_collection_secondary")));
-        ids = LidVidUtils.getAllLidVidsByLids(ctlContext, 
+        ids = LidVidUtils.getAllLidVidsByLids(ctlContext,
         		RequestBuildContextFactory.given(false, "lidvid", ReferencingLogicTransmuter.Collection.impl().constraints()),
         		ids);
         lidvids.addAll(ids);
@@ -92,8 +93,8 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic
     }
 
     /**
-     * Get collections of a bundle by bundle LIDVID. 
-     * If a bundle has LIDVID collection references, then those collections are returned. 
+     * Get collections of a bundle by bundle LIDVID.
+     * If a bundle has LIDVID collection references, then those collections are returned.
      * If a bundle has LID collection references, then the latest versions of collections are returned.
      * @return a list of collection LIDVIDs
      * @throws IOException IO exception
@@ -101,19 +102,19 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic
      */
     static private Pagination<String> getBundleCollectionLidVids(
     		LidvidsContext idContext,
-    		ControlContext ctlContext) 
+    		ControlContext ctlContext)
             throws IOException, LidVidNotFoundException
     {
         // Fetch collection references only.
     	List<String> fields = Arrays.asList("ref_lidvid_collection","ref_lidvid_collection_secondary",
                                             "ref_lid_collection", "ref_lid_collection_secondary");
-    	
+
         // Get bundle by lidvid.
         SearchRequest request = new SearchRequestFactory(RequestConstructionContextFactory.given(idContext.getLidVid()), ctlContext.getConnection())
         		.build(RequestBuildContextFactory.given(true, fields,
         				ReferencingLogicTransmuter.Bundle.impl().constraints()),
         				ctlContext.getConnection().getRegistryIndex());
-        
+
         // Call opensearch
         SearchHit hit;
         SearchHits hits = ctlContext.getConnection().getRestHighLevelClient().search(request, RequestOptions.DEFAULT).getHits();
@@ -126,11 +127,11 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic
         List<String> ids = new ArrayList<String>();
         Map<String, Object> fieldMap = hit.getSourceAsMap();
         PaginationLidvidBuilder lidvids = new PaginationLidvidBuilder(idContext);
-        
+
         ids.addAll(lidvids.convert(fieldMap.get("ref_lidvid_collection")));
         ids.addAll(lidvids.convert(fieldMap.get("ref_lidvid_collection_secondary")));
-        
-        // !!! NOTE !!! 
+
+        // !!! NOTE !!!
         // Harvest converts LIDVID references to LID references and stores them in
         // "ref_lid_collection" and "ref_lid_collection_secondary" fields.
         // To get "real" LID references, we have to exclude LIDVID references from these fields.
@@ -144,12 +145,12 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic
                 lidsToRemove.add(lid);
             }
         }
-        
+
         // Lid references (e.g., Kaguya bundle) plus LIDVID references converted by Harvest
         List<String> lids = new ArrayList<String>();
         lids.addAll(lidvids.convert(fieldMap.get("ref_lid_collection")));
         lids.addAll(lidvids.convert(fieldMap.get("ref_lid_collection_secondary")));
-        
+
         // Get "real" LIDs
         if(!lidsToRemove.isEmpty())
         { lids.removeAll(lidsToRemove); }
@@ -157,7 +158,7 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic
         // Get the latest versions of LIDs
         lidvids.addAll(LidVidUtils.getLatestLidVidsByLids(ctlContext,
         		RequestBuildContextFactory.given(true, "lid",
-        				ReferencingLogicTransmuter.Collection.impl().constraints()), lids));       
+        				ReferencingLogicTransmuter.Collection.impl().constraints()), lids));
         return lidvids;
     }
 
@@ -191,7 +192,7 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic
 				(context, input, RefLogicBundle.children(context, input.getSelector(), input));
 	}
 
-    
+
     @Override
 	public RequestAndResponseContext memberOf(ControlContext context, UserContext input, boolean twoSteps)
 			throws ApplicationTypeException, IOException, LidVidNotFoundException, MembershipException,

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 
 import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
+import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,15 +87,15 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic
     		                              "ref_lidvid_collection", "ref_lidvid_collection_secondary");
     	List<String> sortedLids;
     	Set<String> lids = new HashSet<String>();
-    	String lid = LidVidUtils.parseLid(uid.getLidVid());
+    	PdsProductIdentifier productIdentifier = PdsProductIdentifier.fromString(uid.getLidVid());
         PaginationLidvidBuilder bundleLidvids = new PaginationLidvidBuilder(uid);
 
-        log.info("Find parents of a colletion -- both all and latest");
-        log.info("Find parents of collenction: " + uid.getLidVid() + "  --- " + LidVidUtils.parseLid(uid.getLidVid()));
+        log.info("Find parents of a collection -- both all and latest");
+        log.info("Find parents of collection: " + uid.getLidVid() + "  --- " + productIdentifier.getLid().toString());
         for (String key : keys)
         {
         	for (final Map<String,Object> kvp : new HitIterator(control.getConnection().getRestHighLevelClient(),
-        			new SearchRequestFactory(RequestConstructionContextFactory.given(key, lid, true), control.getConnection())
+        			new SearchRequestFactory(RequestConstructionContextFactory.given(key, productIdentifier.getLid().toString(), true), control.getConnection())
         			.build(RequestBuildContextFactory.given(true, "lid", ReferencingLogicTransmuter.Bundle.impl().constraints()),
         					control.getConnection().getRegistryIndex())))
         	{
@@ -102,7 +103,7 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic
         	}
         }
         sortedLids = new ArrayList<String>(lids);
-        Collections.sort(sortedLids);
+        Collections.sort(sortedLids);  // TODO: Implement comparison for PdsLids (only with other PdsLids)
 
         if (selection == ProductVersionSelector.ALL)
         	bundleLidvids.addAll (LidVidUtils.getAllLidVidsByLids(control, RequestBuildContextFactory.empty(), sortedLids));

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
@@ -108,7 +108,7 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic
         }
         sortedLidStrings = new ArrayList<String>(lids);
         Collections.sort(sortedLidStrings);  // TODO: Implement comparison for PdsLids (only with other PdsLids)
-		List<PdsProductIdentifier> sortedLids = sortedLidStrings.stream().map(PdsLid::fromString).collect(Collectors.toList());
+        List<PdsProductIdentifier> sortedLids = sortedLidStrings.stream().map(PdsLid::fromString).collect(Collectors.toList());
 
         if (selection == ProductVersionSelector.ALL){
 			bundleLidvids.addAll(LidVidUtils.getAllLidVidsByLids(control, RequestBuildContextFactory.empty(), sortedLidStrings));

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicProduct.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicProduct.java
@@ -9,8 +9,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
+import gov.nasa.pds.api.registry.model.identifiers.PdsLid;
+import gov.nasa.pds.api.registry.model.identifiers.PdsLidVid;
+import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +64,7 @@ class RefLogicProduct extends RefLogicAny implements ReferencingLogic
     static Pagination<String> parents (ControlContext control, ProductVersionSelector selection, LidvidsContext uid)
     		throws IOException, LidVidNotFoundException
     {
-    	List<String> sorted_lids;
+    	List<String> sortedLidStrings;
         PaginationLidvidBuilder parents = new PaginationLidvidBuilder(uid);
         Set<String> lids = new HashSet<String>();
 
@@ -69,13 +73,18 @@ class RefLogicProduct extends RefLogicAny implements ReferencingLogic
         		new SearchRequestFactory(RequestConstructionContextFactory.given("product_lidvid", uid.getLidVid(), true), control.getConnection())
         		.build (RequestBuildContextFactory.given(true, "collection_lid"), control.getConnection().getRegistryRefIndex())))
 		{ lids.addAll(parents.convert(kvp.get("collection_lid"))); }
-        sorted_lids = new ArrayList<String>(lids);
-        Collections.sort(sorted_lids);
+        sortedLidStrings = new ArrayList<>(lids);
+        Collections.sort(sortedLidStrings);
+		List<PdsProductIdentifier> sortedLids = sortedLidStrings.stream().map(PdsLid::fromString).collect(Collectors.toList());
 
-        if (selection == ProductVersionSelector.ALL)
-        	parents.addAll (LidVidUtils.getAllLidVidsByLids(control, RequestBuildContextFactory.empty(), sorted_lids));
-        else
-        	parents.addAll(LidVidUtils.getLatestLidVidsByLids(control, RequestBuildContextFactory.empty(), sorted_lids));
+        if (selection == ProductVersionSelector.ALL){
+			parents.addAll (LidVidUtils.getAllLidVidsByLids(control, RequestBuildContextFactory.empty(), sortedLidStrings));
+		}
+        else{
+			List<PdsLidVid> latestLidVids = LidVidUtils.getLatestLidVidsForProductIdentifiers(control, RequestBuildContextFactory.empty(), sortedLids);
+			List<String> latestLidVidStrings = latestLidVids.stream().map(PdsLidVid::toString).collect(Collectors.toList());
+			parents.addAll(latestLidVidStrings);
+		}
 
         return parents;
     }

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicProduct.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicProduct.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +33,7 @@ class RefLogicProduct extends RefLogicAny implements ReferencingLogic
 	private static final Logger log = LoggerFactory.getLogger(RefLogicProduct.class);
 
     @Override
-	public GroupConstraint constraints() 
+	public GroupConstraint constraints()
 	{
     	Map<String,List<String>> preset = new HashMap<String,List<String>>();
     	preset.put("product_class", Arrays.asList("Product_Bundle","Product_Collection"));

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RequestAndResponseContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RequestAndResponseContext.java
@@ -91,7 +91,7 @@ public class RequestAndResponseContext implements RequestBuildContext,RequestCon
     		GroupConstraint outPreset, GroupConstraint resPreset // criteria for defining last node (outPreset) and first node (resOutput) for any endpoint
     		) throws ApplicationTypeException,LidVidNotFoundException,IOException
     {
-		ProductVersionSelector versionSelectionScope = outPreset.equals(resPreset) ? parameters.getSelector() : ProductVersionSelector.TYPED;
+		ProductVersionSelector versionSelectionScope = outPreset.equals(resPreset) ? parameters.getSelector() : ProductVersionSelector.SPECIFIC;
 
 		Map<String, ProductBusinessLogic> formatters = new HashMap<String, ProductBusinessLogic>();
     	formatters.put("*/*", new PdsProductBusinessObject());

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RequestAndResponseContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RequestAndResponseContext.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
+import gov.nasa.pds.api.registry.model.identifiers.PdsLidVid;
 import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.client.RequestOptions;
@@ -41,7 +42,7 @@ public class RequestAndResponseContext implements RequestBuildContext,RequestCon
     final private ControlContext controlContext;
 	final private String queryString;
 	final private List<String> keywords;
-	final private String lidvid;
+	final private PdsProductIdentifier productIdentifier;
     final private List<String> fields;
     final private List<String> sort;
     final private int start;
@@ -113,12 +114,11 @@ public class RequestAndResponseContext implements RequestBuildContext,RequestCon
     	this.keywords = parameters.getKeywords();
     	this.fields = new ArrayList<String>();
     	this.fields.addAll(this.add_output_needs (parameters.getFields()));
-		PdsProductIdentifier productIdentifier = LidVidUtils.resolve(
+		this.productIdentifier = LidVidUtils.resolve(
 				parameters.getIdentifier(),
 				versionSelectionScope,
 				controlContext,
 				RequestBuildContextFactory.given(parameters.getSelector() == ProductVersionSelector.LATEST, fields, resPreset));
-		this.lidvid = productIdentifier != null ? productIdentifier.toString() : "";
    		this.summaryOnly = parameters.isSummaryOnly();
    		this.limit = parameters.getLimit();
     	this.sort = parameters.getSort();
@@ -132,7 +132,8 @@ public class RequestAndResponseContext implements RequestBuildContext,RequestCon
     @Override
     public Map<String, List<String>> getKeyValuePairs() { return new HashMap<String,List<String>>(); }
     @Override
-    public String getLIDVID() { return this.lidvid; }
+	public PdsProductIdentifier getProductIdentifier() { return this.productIdentifier; }
+	public String getProductIdentifierString() { return this.productIdentifier.toString(); }
 	public final List<String> getFields() { return this.fields; }
 	public final List<String> getSort() { return this.sort; }
 	public int getStart() { return this.start; }
@@ -225,7 +226,7 @@ public class RequestAndResponseContext implements RequestBuildContext,RequestCon
 			for (String field : this.getFields()) log.warn("      " + field);
 			log.warn("   keyword: " + String.valueOf(this.getKeywords().size()));
 			for (String keyword : this.getKeywords()) log.warn("    " + keyword);
-			log.warn("   lidvid: " + this.getLIDVID());
+			log.warn("   lidvid: " + this.getProductIdentifierString());
 			log.warn("   limit: " + String.valueOf(this.getLimit()));
 			log.warn("   query string: " + String.valueOf(this.getQueryString()));
 			log.warn("   selector: " + String.valueOf(this.getSelector()));

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RequestAndResponseContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RequestAndResponseContext.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
+import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
@@ -112,11 +113,12 @@ public class RequestAndResponseContext implements RequestBuildContext,RequestCon
     	this.keywords = parameters.getKeywords();
     	this.fields = new ArrayList<String>();
     	this.fields.addAll(this.add_output_needs (parameters.getFields()));
-		this.lidvid = LidVidUtils.resolve(
-    			parameters.getIdentifier(),
+		PdsProductIdentifier productIdentifier = LidVidUtils.resolve(
+				parameters.getIdentifier(),
 				versionSelectionScope,
-    			controlContext,
-    			RequestBuildContextFactory.given(parameters.getSelector() == ProductVersionSelector.LATEST, fields, resPreset));
+				controlContext,
+				RequestBuildContextFactory.given(parameters.getSelector() == ProductVersionSelector.LATEST, fields, resPreset));
+		this.lidvid = productIdentifier != null ? productIdentifier.toString() : "";
    		this.summaryOnly = parameters.isSummaryOnly();
    		this.limit = parameters.getLimit();
     	this.sort = parameters.getSort();

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RequestAndResponseContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RequestAndResponseContext.java
@@ -148,7 +148,10 @@ public class RequestAndResponseContext implements RequestBuildContext,RequestCon
 	@Override
 	public boolean isTerm() { return true; } // no way to make this decision here so always term for lidvid
 	@Override
-	public boolean justLatest() { return getSelector() == ProductVersionSelector.LATEST; }
+	public boolean justLatest() {
+		boolean specificVersionRequested = this.productIdentifier instanceof PdsLidVid;
+		return getSelector() == ProductVersionSelector.LATEST && !specificVersionRequested;
+	}
 
 	private List<String> add_output_needs (List<String> given) throws ApplicationTypeException
 	{

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
@@ -73,7 +73,7 @@ public class LidVidUtils
 
     	if (searchResponse != null)
     	{
-    		ArrayList<PdsLidVid> lidVids = new ArrayList<PdsLidVid>();
+    		List<PdsLidVid> lidVids = new ArrayList<PdsLidVid>();
     		for (SearchHit searchHit : searchResponse.getHits())
     		{
     			String lidvidStr = (String)searchHit.getSourceAsMap().get("lidvid");;

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
@@ -117,7 +117,7 @@ public class LidVidUtils
 		PdsProductIdentifier productIdentifier = PdsProductIdentifier.fromString(_identifier);
     	PdsProductIdentifier result = null;
 
-    	if (_identifier.length() > 0)
+    	if (productIdentifier != null)
     	{
     		/* YUCK! This should use polymorphism in ProductVersionSelector not a switch statement */
     		switch (scope)
@@ -135,10 +135,8 @@ public class LidVidUtils
     		default: throw new LidVidNotFoundException("Unknown and unhandles ProductVersionSelector value.");
     		}
     	}
-		// When this function's interface is converted to use PdsProductIdentifiers, excise the non-const variable
-		// "result" and return within the switch statement if possible (need to check).
-		assert result != null;
-		return result.toString();
+
+		return productIdentifier != null ? productIdentifier.toString() : "";
     }
 
 	public static void verify (ControlContext control, UserContext user)

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
@@ -128,7 +128,7 @@ public class LidVidUtils
     		case LATEST:
     			result = LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext, productIdentifier.getLid().toString());
     			break;
-    		case TYPED:
+    		case SPECIFIC:
 				result = productIdentifier instanceof PdsLidVid ? productIdentifier : LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext, productIdentifier.getLid().toString());
     			break;
     		case ORIGINAL: throw new LidVidNotFoundException("ProductVersionSelector.ORIGINAL not supported");

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
@@ -126,7 +126,11 @@ public class LidVidUtils
     			result = productIdentifier.getLid();
     			break;
     		case LATEST:
-    			result = LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext, productIdentifier.getLid().toString());
+//				Per discussion with Al Niessner, the intended functionality of attempting to resolve a LIDVID with
+//				selector LATEST is that it should return the exact product specified by the LIDVID, *not* the latest
+//				equivalent product.  This is somewhat unintuitive, but ProductVersionSelector's purpose is not actually
+//				to force that kind of resolution.
+				result = productIdentifier instanceof PdsLidVid ? productIdentifier : LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext, productIdentifier.getLid().toString());
     			break;
     		case SPECIFIC:
 				result = productIdentifier instanceof PdsLidVid ? productIdentifier : LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext, productIdentifier.getLid().toString());
@@ -136,7 +140,7 @@ public class LidVidUtils
     		}
     	}
 
-		return productIdentifier;
+		return result;
     }
 
 	public static void verify (ControlContext control, UserContext user)

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
@@ -1,4 +1,4 @@
-package gov.nasa.pds.api.registry.model;
+package gov.nasa.pds.api.registry.model.identifiers;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -6,6 +6,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import gov.nasa.pds.api.registry.model.ProductVersionSelector;
+import gov.nasa.pds.api.registry.model.ReferencingLogicTransmuter;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
@@ -108,7 +108,7 @@ public class LidVidUtils
     	return lidvids;
     }
 
-    public static String resolve (
+    public static PdsProductIdentifier resolve (
     		String _identifier,
     		ProductVersionSelector scope,
     		ControlContext ctlContext,
@@ -136,7 +136,7 @@ public class LidVidUtils
     		}
     	}
 
-		return productIdentifier != null ? productIdentifier.toString() : "";
+		return productIdentifier;
     }
 
 	public static void verify (ControlContext control, UserContext user)

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
@@ -40,23 +40,23 @@ public class LidVidUtils
     /**
      * Get latest versions of LIDs
      */
-    public static List<String> getLatestLidVidsByLids(
+    public static List<PdsLidVid> getLatestLidVidsForProductIdentifiers(
     		ControlContext ctlContext,
     		RequestBuildContext reqContext,
-            Collection<String> lids) throws IOException,LidVidNotFoundException
+            Collection<PdsProductIdentifier> productIdentifiers) throws IOException,LidVidNotFoundException
     {
-    	List<PdsLidVid> lidVids = new ArrayList<PdsLidVid>();
+    	List<PdsLidVid> lidVids = new ArrayList<>();
 
-    	for (String lid : lids) {
+    	for (PdsProductIdentifier id : productIdentifiers) {
 			try {
-				PdsLidVid latestLidVid = LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext, lid);
+				PdsLidVid latestLidVid = LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext, id.getLid().toString());
 				lidVids.add(latestLidVid);
 			} catch (LidVidNotFoundException e) {
-				log.error("Database is corrupted. Have reference to LID but cannot find it: " + lid);
+				log.error("Database is corrupted. Have reference to LID but cannot find it: " + id.getLid().toString());
 			}
 		}
 
-    	return lidVids.stream().map(PdsLidVid::toString).collect(Collectors.toList());  // Required as callers aren't yet compatible with LIDVID classes
+    	return lidVids;
     }
 
     public static PdsLidVid getLatestLidVidByLid(

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
@@ -35,18 +35,7 @@ import gov.nasa.pds.api.registry.search.SearchRequestFactory;
  */
 public class LidVidUtils
 {
-	private static final String LIDVID_SEPARATOR = "::";
 	private static final Logger log = LoggerFactory.getLogger(LidVidUtils.class);
-
-	public static String parseLid(String productIdentifier)
-    {
-        if (productIdentifier == null) {
-			return null;
-		}
-
-		return PdsProductIdentifier.fromString(productIdentifier).getLid().toString();
-    }
-
 
     /**
      * Get latest versions of LIDs

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsLid.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsLid.java
@@ -1,4 +1,4 @@
-package gov.nasa.pds.api.registry.model;
+package gov.nasa.pds.api.registry.model.identifiers;
 
 public class PdsLid {
     private String value;

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsLid.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsLid.java
@@ -1,6 +1,6 @@
 package gov.nasa.pds.api.registry.model.identifiers;
 
-public class PdsLid {
+public class PdsLid extends PdsProductIdentifier{
     private String value;
 
     public PdsLid(String value) {
@@ -10,9 +10,19 @@ public class PdsLid {
     public String getValue() {
         return this.value;
     }
+
+    @Override
+    public PdsLid getLid() {
+        return this;
+    }
+
     @Override
     public String toString() {
         return this.value;
+    }
+
+    public static PdsLid fromString(String lid) {
+        return new PdsLid(lid);
     }
 
     @Override

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsLidVid.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsLidVid.java
@@ -1,6 +1,6 @@
 package gov.nasa.pds.api.registry.model.identifiers;
 
-public class PdsLidVid implements Comparable<PdsLidVid>{
+public class PdsLidVid extends PdsProductIdentifier implements Comparable<PdsLidVid>{
     private final PdsLid lid;
     private final PdsVid vid;
 
@@ -18,7 +18,7 @@ public class PdsLidVid implements Comparable<PdsLidVid>{
     }
 
     public static PdsLidVid fromString(String lidVidString) {
-        String[] chunks = lidVidString.split("::");
+        String[] chunks = lidVidString.split(LIDVID_SEPARATOR);
 
         if (chunks.length != 2) {
             String errMsg = String.format("Provided value '%s' is not a valid LIDVID", lidVidString);

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsLidVid.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsLidVid.java
@@ -1,4 +1,4 @@
-package gov.nasa.pds.api.registry.model;
+package gov.nasa.pds.api.registry.model.identifiers;
 
 public class PdsLidVid implements Comparable<PdsLidVid>{
     private final PdsLid lid;

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsProductIdentifier.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsProductIdentifier.java
@@ -1,0 +1,13 @@
+package gov.nasa.pds.api.registry.model.identifiers;
+
+public abstract class PdsProductIdentifier {
+    protected static final String LIDVID_SEPARATOR = "::";
+
+    public abstract PdsLid getLid();
+    @Override
+    public abstract String toString();
+
+    public static PdsProductIdentifier fromString(String identifier) {
+        return identifier.contains(LIDVID_SEPARATOR) ? PdsLidVid.fromString(identifier) : PdsLid.fromString(identifier);
+    }
+}

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsProductIdentifier.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsProductIdentifier.java
@@ -8,6 +8,14 @@ public abstract class PdsProductIdentifier {
     public abstract String toString();
 
     public static PdsProductIdentifier fromString(String identifier) {
-        return identifier.contains(LIDVID_SEPARATOR) ? PdsLidVid.fromString(identifier) : PdsLid.fromString(identifier);
+        try {
+            return identifier.contains(LIDVID_SEPARATOR) ? PdsLidVid.fromString(identifier) : PdsLid.fromString(identifier);
+        } catch (IllegalArgumentException err) {
+            return resolvePartialLidVid(identifier);
+        }
+    }
+
+    private static PdsLid resolvePartialLidVid(String identifier) {
+        return PdsLid.fromString(identifier.split(LIDVID_SEPARATOR)[0]);
     }
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsProductIdentifier.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsProductIdentifier.java
@@ -8,6 +8,8 @@ public abstract class PdsProductIdentifier {
     public abstract String toString();
 
     public static PdsProductIdentifier fromString(String identifier) {
+        if (identifier.length() == 0) return null;
+
         try {
             return identifier.contains(LIDVID_SEPARATOR) ? PdsLidVid.fromString(identifier) : PdsLid.fromString(identifier);
         } catch (IllegalArgumentException err) {

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsVid.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsVid.java
@@ -1,4 +1,4 @@
-package gov.nasa.pds.api.registry.model;
+package gov.nasa.pds.api.registry.model.identifiers;
 
 public class PdsVid implements Comparable<PdsVid> {
     private final int majorVersion;

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/SearchRequestFactory.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/SearchRequestFactory.java
@@ -3,6 +3,8 @@ package gov.nasa.pds.api.registry.search;
 import java.util.List;
 import java.util.Map;
 
+import gov.nasa.pds.api.registry.model.identifiers.PdsLidVid;
+import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -62,7 +64,8 @@ public class SearchRequestFactory
 
     	if (!context.getLIDVID().isBlank())
     	{
-    		String key = LidVidUtils.parseLid(context.getLIDVID()).equals(context.getLIDVID()) ? "lid" : "lidvid";
+			PdsProductIdentifier productIdentifier = PdsProductIdentifier.fromString(context.getLIDVID());
+			String key = productIdentifier instanceof PdsLidVid ? "lidvid" : "lid";
 
     		this.base.must(QueryBuilders.termQuery(key, context.getLIDVID())); // term is exact match which lidvid look should be
     	}

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/SearchRequestFactory.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/SearchRequestFactory.java
@@ -16,7 +16,6 @@ import gov.nasa.pds.api.registry.ConnectionContext;
 import gov.nasa.pds.api.registry.RequestBuildContext;
 import gov.nasa.pds.api.registry.RequestConstructionContext;
 import gov.nasa.pds.api.registry.model.BlobUtil;
-import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
 import gov.nasa.pds.api.registry.model.ProductQueryBuilderUtil;
 
 public class SearchRequestFactory
@@ -62,12 +61,12 @@ public class SearchRequestFactory
     		{ this.base.must (QueryBuilders.queryStringQuery(keyword).field("title").field("description")); });
     	}
 
-    	if (!context.getLIDVID().isBlank())
+    	if (context.getProductIdentifier() != null)
     	{
-			PdsProductIdentifier productIdentifier = PdsProductIdentifier.fromString(context.getLIDVID());
+			PdsProductIdentifier productIdentifier = PdsProductIdentifier.fromString(context.getProductIdentifierString());
 			String key = productIdentifier instanceof PdsLidVid ? "lidvid" : "lid";
 
-    		this.base.must(QueryBuilders.termQuery(key, context.getLIDVID())); // term is exact match which lidvid look should be
+    		this.base.must(QueryBuilders.termQuery(key, context.getProductIdentifierString())); // term is exact match which lidvid look should be
     	}
     }
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/SearchRequestFactory.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/SearchRequestFactory.java
@@ -14,7 +14,7 @@ import gov.nasa.pds.api.registry.ConnectionContext;
 import gov.nasa.pds.api.registry.RequestBuildContext;
 import gov.nasa.pds.api.registry.RequestConstructionContext;
 import gov.nasa.pds.api.registry.model.BlobUtil;
-import gov.nasa.pds.api.registry.model.LidVidUtils;
+import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
 import gov.nasa.pds.api.registry.model.ProductQueryBuilderUtil;
 
 public class SearchRequestFactory

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/SimpleRequestConstructionContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/SimpleRequestConstructionContext.java
@@ -6,39 +6,40 @@ import java.util.List;
 import java.util.Map;
 
 import gov.nasa.pds.api.registry.RequestConstructionContext;
+import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 
 class SimpleRequestConstructionContext implements RequestConstructionContext
 {
 	final private boolean isTerm;
 	final private Map<String,List<String>> kvps;
-	final private String lidvid;
-	
+	final private PdsProductIdentifier productIdentifier;
+
 	SimpleRequestConstructionContext (Map<String,List<String>> kvps)
 	{
 		this.isTerm = false;
 		this.kvps = kvps;
-		this.lidvid = "";
+		this.productIdentifier = null;
 	}
-	
+
 	SimpleRequestConstructionContext (Map<String,List<String>> kvps, boolean asTerm)
 	{
 		this.isTerm = asTerm;
 		this.kvps = kvps;
-		this.lidvid = "";
+		this.productIdentifier = null;
 	}
-	
-	SimpleRequestConstructionContext (String lidvid)
+
+	SimpleRequestConstructionContext (String productIdentifier)
 	{
 		this.isTerm = false;
 		this.kvps = new HashMap<String,List<String>>();
-		this.lidvid = lidvid;
+		this.productIdentifier = PdsProductIdentifier.fromString(productIdentifier);
 	}
-	
-	SimpleRequestConstructionContext (String lidvid, boolean isTerm)
+
+	SimpleRequestConstructionContext (String productIdentifier, boolean isTerm)
 	{
 		this.isTerm = isTerm;
 		this.kvps = new HashMap<String,List<String>>();
-		this.lidvid = lidvid;
+		this.productIdentifier = PdsProductIdentifier.fromString(productIdentifier);
 	}
 
 	@Override
@@ -48,7 +49,10 @@ class SimpleRequestConstructionContext implements RequestConstructionContext
 	public Map<String, List<String>> getKeyValuePairs() { return this.kvps; }
 
 	@Override
-	public String getLIDVID() { return this.lidvid; }
+	public PdsProductIdentifier getProductIdentifier() { return this.productIdentifier; }
+
+	@Override
+	public String getProductIdentifierString() { return this.productIdentifier == null ? "" : this.productIdentifier.toString(); }
 
 	@Override
 	public String getQueryString() { return ""; }

--- a/service/src/test/java/gov/nasa/pds/api/registry/model/PdsLidTest.java
+++ b/service/src/test/java/gov/nasa/pds/api/registry/model/PdsLidTest.java
@@ -1,5 +1,6 @@
 package gov.nasa.pds.api.registry.model;
 
+import gov.nasa.pds.api.registry.model.identifiers.PdsLid;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/service/src/test/java/gov/nasa/pds/api/registry/model/PdsLidVidTest.java
+++ b/service/src/test/java/gov/nasa/pds/api/registry/model/PdsLidVidTest.java
@@ -1,10 +1,9 @@
 package gov.nasa.pds.api.registry.model;
 
+import gov.nasa.pds.api.registry.model.identifiers.PdsLidVid;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.sql.Array;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/service/src/test/java/gov/nasa/pds/api/registry/model/PdsProductIdentifierTest.java
+++ b/service/src/test/java/gov/nasa/pds/api/registry/model/PdsProductIdentifierTest.java
@@ -1,0 +1,18 @@
+package gov.nasa.pds.api.registry.model;
+
+import gov.nasa.pds.api.registry.model.identifiers.PdsLid;
+import gov.nasa.pds.api.registry.model.identifiers.PdsLidVid;
+import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PdsProductIdentifierTest {
+    @Test
+    public void testSubclassObjectFactory() {
+        PdsProductIdentifier lid = PdsProductIdentifier.fromString("urn:nasa:pds:epoxi");
+        Assert.assertTrue(lid instanceof PdsLid);
+
+        PdsProductIdentifier lidvid = PdsProductIdentifier.fromString("urn:nasa:pds:epoxi::1.0");
+        Assert.assertTrue(lidvid instanceof PdsLidVid);
+    }
+}

--- a/service/src/test/java/gov/nasa/pds/api/registry/model/PdsProductIdentifierTest.java
+++ b/service/src/test/java/gov/nasa/pds/api/registry/model/PdsProductIdentifierTest.java
@@ -14,5 +14,18 @@ public class PdsProductIdentifierTest {
 
         PdsProductIdentifier lidvid = PdsProductIdentifier.fromString("urn:nasa:pds:epoxi::1.0");
         Assert.assertTrue(lidvid instanceof PdsLidVid);
+
+        PdsProductIdentifier lidnull = PdsProductIdentifier.fromString("urn:nasa:pds:epoxi::");
+        Assert.assertTrue(lidnull instanceof PdsLid);
+        Assert.assertEquals("urn:nasa:pds:epoxi", lidnull.getLid().toString());
+
+        PdsProductIdentifier lidv = PdsProductIdentifier.fromString("urn:nasa:pds:epoxi::1");
+        Assert.assertTrue(lidv instanceof PdsLid);
+        Assert.assertEquals("urn:nasa:pds:epoxi", lidv.getLid().toString());
+
+        PdsProductIdentifier lidvi = PdsProductIdentifier.fromString("urn:nasa:pds:epoxi::1.");
+        Assert.assertTrue(lidvi instanceof PdsLid);
+        Assert.assertEquals("urn:nasa:pds:epoxi", lidv.getLid().toString());
+
     }
 }

--- a/service/src/test/java/gov/nasa/pds/api/registry/model/PdsVidTest.java
+++ b/service/src/test/java/gov/nasa/pds/api/registry/model/PdsVidTest.java
@@ -1,5 +1,6 @@
 package gov.nasa.pds.api.registry.model;
 
+import gov.nasa.pds.api.registry.model.identifiers.PdsVid;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
## 🗒️ Summary
Implements a `PdsProductIdentifier` parent class of `PdsLid` and `PdsLidVid` and sinks its teeth into the codebase (i.e. changes interfaces of a large quantity of functions to use the new classes instead of `String`s).  This relates to #234 but is much bigger than a simple fix for that one ticket.

I don't expect anyone to read through the bulk of it, but I'd like to get feedback on the implementation of the `PdsProductIdentifier` class, and the general position that LID/LIDVID strings should be converted to/from `PdsProductIdentifier` objects as close as possible to the API's/Java's interface with external services.

If anyone _does_ hate themselves enough to look closely, bear in mind that it's a work in progress and the expansion of mandatory `PdsProductIdentifier`-ness necessitates a bunch of temporary code at the incrementally-expanding interfaces (hence all the streaming collections back and forth between `Strings` and `PdsProductIdentifiers`).

The job's only half-done, but better that I get feedback now than after spending a bunch more time if there are problems with the general approach.

Resolves #234 