### PR TITLE
261: lookup product class when group not explicitly given

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 
 <!--
-👉 This is the TEMPLATE project object model or `pom.xml` file.
+This is the TEMPLATE project object model or `pom.xml` file.
 
 Go through this file line-by-line and replace the template values with your own.
 -->
@@ -225,7 +225,7 @@ Go through this file line-by-line and replace the template values with your own.
                                 <goals>
                                     <goal>jar</goal>
                                     <goal>test-jar</goal>
-                                </goals> 
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/Member.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/Member.java
@@ -15,6 +15,7 @@ import gov.nasa.pds.api.registry.exceptions.NothingFoundException;
 import gov.nasa.pds.api.registry.exceptions.UnknownGroupNameException;
 import gov.nasa.pds.api.registry.model.ReferencingLogicTransmuter;
 import gov.nasa.pds.api.registry.model.RequestAndResponseContext;
+import gov.nasa.pds.api.registry.search.QuickSearch;
 
 class Member implements EndpointHandler
 {
@@ -30,7 +31,11 @@ class Member implements EndpointHandler
 			throws ApplicationTypeException, IOException, LidVidNotFoundException, MembershipException,
 			NothingFoundException, UnknownGroupNameException
 	{
-		ReferencingLogic transmuter = ReferencingLogicTransmuter.getBySwaggerGroup(content.getGroup()).impl();
+		ReferencingLogic transmuter;
+		
+		if (0 < content.getGroup().length()) transmuter = ReferencingLogicTransmuter.getBySwaggerGroup(content.getGroup()).impl();
+		else transmuter = ReferencingLogicTransmuter.getByProductClass(QuickSearch.getValue(control.getConnection(), false, content.getLidVid(), "product_class")).impl();
+
 		RequestAndResponseContext context = this.offspring ? transmuter.member(control, content, this.twoSteps) :
 			                                                 transmuter.memberOf(control, content, this.twoSteps);
 		return new ResponseEntity<Object>(context.getResponse(), HttpStatus.OK);

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import gov.nasa.pds.api.registry.RequestBuildContext;
 import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
 import gov.nasa.pds.api.registry.model.identifiers.PdsLidVid;
 import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
@@ -161,15 +162,14 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic
 
         // Get the latest versions of LIDs
         List<PdsProductIdentifier> productIdentifiers = lidStrings.stream().map(PdsProductIdentifier::fromString).collect(Collectors.toList());
-        try {
-            List<PdsLidVid> latestLidVids = LidVidUtils.getLatestLidVidsForProductIdentifiers(
-                    ctlContext,
-                    RequestBuildContextFactory.given(true, "lid", ReferencingLogicTransmuter.Collection.impl().constraints()),
-                    productIdentifiers);
-            List<String> latestLidVidStrings = latestLidVids.stream().map(PdsLidVid::toString).collect(Collectors.toList());
-            lidvids.addAll(latestLidVidStrings);
-        } catch (LidVidNotFoundException e) {
-            log.error("Database referential integrity error -  LID is referenced but does not exist in db: " + e.toString());
+        RequestBuildContext reqContext = RequestBuildContextFactory.given(true, "lid", ReferencingLogicTransmuter.Collection.impl().constraints());
+        for (PdsProductIdentifier id : productIdentifiers) {
+            try {
+                PdsLidVid latestLidVid = LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext, id.getLid().toString());
+                lidvids.add(latestLidVid.toString());
+            } catch (LidVidNotFoundException e) {
+                log.warn("Database referential integrity error -  LID is referenced but does not exist in db: " + e.toString());
+            }
         }
 
         return lidvids;

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
@@ -168,7 +168,7 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic
                 PdsLidVid latestLidVid = LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext, id.getLid().toString());
                 lidvids.add(latestLidVid.toString());
             } catch (LidVidNotFoundException e) {
-                log.warn("Database referential integrity error -  LID is referenced but does not exist in db: " + e.toString());
+                log.warn("LID is referenced but is in non-findable archive-status or does not exist in db: " + e.toString());
             }
         }
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
@@ -132,7 +132,7 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic
 					PdsLidVid latestLidvid = LidVidUtils.getLatestLidVidByLid(control, reqContext, lid.getLid().toString());
 					bundleLidvids.add(latestLidvid.toString());
 				} catch (LidVidNotFoundException e) {
-					log.warn("Database referential integrity error -  LID is referenced but does not exist in db: " + e.toString());
+					log.warn("LID is referenced but is in non-findable archive-status or does not exist in db: " + e.toString());
 				}
 			}
 		}

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
@@ -120,19 +120,20 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic
         	}
         }
         sortedLidStrings = new ArrayList<String>(lids);
-        Collections.sort(sortedLidStrings);  // TODO: Implement comparison for PdsLids (only with other PdsLids)
-        List<PdsProductIdentifier> sortedLids = sortedLidStrings.stream().map(PdsLid::fromString).collect(Collectors.toList());
+		Collections.sort(sortedLidStrings);  // TODO: Implement comparison for PdsLids (only with other PdsLids)
+		List<PdsProductIdentifier> sortedLids = sortedLidStrings.stream().map(PdsLid::fromString).collect(Collectors.toList());
 
-        if (selection == ProductVersionSelector.ALL){
+		if (selection == ProductVersionSelector.ALL) {
 			bundleLidvids.addAll(LidVidUtils.getAllLidVidsByLids(control, RequestBuildContextFactory.empty(), sortedLidStrings));
-		}
-        else {
-			try {
-				List<PdsLidVid> latestLidvids = LidVidUtils.getLatestLidVidsForProductIdentifiers(control, RequestBuildContextFactory.empty(), sortedLids);
-				List<String> latestLidVidStrings = latestLidvids.stream().map(PdsLidVid::toString).collect(Collectors.toList());
-				bundleLidvids.addAll(latestLidVidStrings);
-			} catch (LidVidNotFoundException e) {
-				log.error("Database referential integrity error -  LID is referenced but does not exist in db: " + e.toString());
+		} else {
+			RequestBuildContext reqContext = RequestBuildContextFactory.empty();
+			for (PdsProductIdentifier lid : sortedLids) {
+				try {
+					PdsLidVid latestLidvid = LidVidUtils.getLatestLidVidByLid(control, reqContext, lid.getLid().toString());
+					bundleLidvids.add(latestLidvid.toString());
+				} catch (LidVidNotFoundException e) {
+					log.warn("Database referential integrity error -  LID is referenced but does not exist in db: " + e.toString());
+				}
 			}
 		}
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicProduct.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicProduct.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import gov.nasa.pds.api.registry.RequestBuildContext;
 import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
 import gov.nasa.pds.api.registry.model.identifiers.PdsLid;
 import gov.nasa.pds.api.registry.model.identifiers.PdsLidVid;
@@ -77,20 +78,20 @@ class RefLogicProduct extends RefLogicAny implements ReferencingLogic
         Collections.sort(sortedLidStrings);
 		List<PdsProductIdentifier> sortedLids = sortedLidStrings.stream().map(PdsLid::fromString).collect(Collectors.toList());
 
-        if (selection == ProductVersionSelector.ALL){
-			parents.addAll (LidVidUtils.getAllLidVidsByLids(control, RequestBuildContextFactory.empty(), sortedLidStrings));
-		}
-        else{
-			try{
-				List<PdsLidVid> latestLidVids = LidVidUtils.getLatestLidVidsForProductIdentifiers(control, RequestBuildContextFactory.empty(), sortedLids);
-				List<String> latestLidVidStrings = latestLidVids.stream().map(PdsLidVid::toString).collect(Collectors.toList());
-				parents.addAll(latestLidVidStrings);
-			} catch (LidVidNotFoundException e) {
-				log.error("Database referential integrity error -  LID is referenced but does not exist in db: " + e.toString());
+		if (selection == ProductVersionSelector.ALL) {
+			parents.addAll(LidVidUtils.getAllLidVidsByLids(control, RequestBuildContextFactory.empty(), sortedLidStrings));
+		} else {
+			RequestBuildContext reqContext = RequestBuildContextFactory.empty();
+			for (PdsProductIdentifier id : sortedLids) {
+				try {
+					PdsLidVid latestLidvid = LidVidUtils.getLatestLidVidByLid(control, reqContext, id.getLid().toString());
+					parents.add(latestLidvid.toString());
+				} catch (LidVidNotFoundException e) {
+					log.warn("Database referential integrity error -  LID is referenced but does not exist in db: " + e.toString());
+				}
 			}
 		}
 
-        return parents;
-    }
-
+		return parents;
+	}
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicProduct.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicProduct.java
@@ -87,7 +87,7 @@ class RefLogicProduct extends RefLogicAny implements ReferencingLogic
 					PdsLidVid latestLidvid = LidVidUtils.getLatestLidVidByLid(control, reqContext, id.getLid().toString());
 					parents.add(latestLidvid.toString());
 				} catch (LidVidNotFoundException e) {
-					log.warn("Database referential integrity error -  LID is referenced but does not exist in db: " + e.toString());
+					log.warn("LID is referenced but is in non-findable archive-status or does not exist in db: " + e.toString());
 				}
 			}
 		}

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
@@ -36,28 +36,6 @@ public class LidVidUtils
 {
 	private static final Logger log = LoggerFactory.getLogger(LidVidUtils.class);
 
-    /**
-     * Get latest versions of LIDs
-     */
-    public static List<PdsLidVid> getLatestLidVidsForProductIdentifiers(
-    		ControlContext ctlContext,
-    		RequestBuildContext reqContext,
-            Collection<PdsProductIdentifier> productIdentifiers) throws IOException,LidVidNotFoundException
-    {
-    	List<PdsLidVid> lidVids = new ArrayList<>();
-
-    	for (PdsProductIdentifier id : productIdentifiers) {
-			try {
-				PdsLidVid latestLidVid = LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext, id.getLid().toString());
-				lidVids.add(latestLidVid);
-			} catch (LidVidNotFoundException e) {
-				throw new LidVidNotFoundException("Could not find any LIDVIDs for LID " + id.getLid().toString());
-			}
-		}
-
-    	return lidVids;
-    }
-
     public static PdsLidVid getLatestLidVidByLid(
     		ControlContext ctlContext,
     		RequestBuildContext reqContext,


### PR DESCRIPTION
## 🗒️ Summary
When using products as general, also need to parse the product class from the DB because the expected group is no longer specified (this is a good thing). Modified the member transmuter to handle this condition.

## ⚙️ Test Data and/or Report

## ♻️ Related Issues
Closes #261 
Closes #268 