### PR TITLE
Add logging messages to CF api rewrite function.

### DIFF
--- a/service/terraform/aws/api_uri_rewrite.js
+++ b/service/terraform/aws/api_uri_rewrite.js
@@ -14,6 +14,7 @@ var VER_IDX = 3
 var CMD_IDX = 4
 
 var TARGET_URI_PREFIX = "/api/search"
+var DEBUG_PARAM       = "cf_debug" 
 
 // The function is in response to the 'viewer request' event
 function handler(event) {
@@ -22,9 +23,9 @@ function handler(event) {
 
     // See if detailed logging is enabled
     var debug = false
-    if ("cf_debug" in request.querystring) {
+    if (DEBUG_PARAM in request.querystring) {
          debug = true
-         delete request.querystring["cf_debug"]
+         delete request.querystring[DEBUG_PARAM]
     }
 
     // Strip out any leading multiple slashies - registry-api#208

--- a/service/terraform/aws/api_uri_rewrite.js
+++ b/service/terraform/aws/api_uri_rewrite.js
@@ -24,6 +24,7 @@ function handler(event) {
     while (incomingUri.indexOf("//") >= 0) {
         incomingUri = incomingUri.replace("//","/");
     }
+    
     // Put the URI back into the request now in case the rewrite doesn't happen
     request.uri = incomingUri
             
@@ -48,11 +49,16 @@ function handler(event) {
                 newUri += "/" + uriParts[i];
             }
 
-            // write the updated URI and the new HTTP header to the request only
-            // if things check out to this point
+            // set updated URI into request and set request node header
             request.uri = newUri;
             request.headers['x-request-node'] = { "value" : resultHeader };
+            console.log("incoming URI [" + incomingUri + "] rewritten to [" + newUri 
+                + "] & x-request-node [" + resultHeader + "]")
+        } else {
+            console.log("incoming URI [" + incomingUri + "] : no rewrite (no command)")
         }
+    } else {
+        console.log("incoming URI [" + incomingUri + "] : no rewrite (no prefix match)")
     }
 
     return request;

--- a/service/terraform/aws/api_uri_rewrite.js
+++ b/service/terraform/aws/api_uri_rewrite.js
@@ -42,10 +42,13 @@ function handler(event) {
 
         if (debug) console.log("incoming URI matches prefix [" + TARGET_URI_PREFIX + "]")
 
-        // split the uri
+        // split the uri - note that w/ a initial '/' the first element in the resulting
+        // array will be empty, so be sure to consider this when computing indexes of
+        // each token
         var uriParts = incomingUri.split("/");
 
-        // at a minimum service, version and command are required, otherwise fall through w/o changes
+        // at a minimum service, version and command are required (i.e. there are non-empty components in the URI after
+        // "/api/search/<version>") in order consider a rewrite of the URI, otherwise fall through w/o changes
         if (uriParts.length > CMD_IDX && uriParts[CMD_IDX].trim() != "") {
             if (debug) console.log("incoming URI includes a command")
 

--- a/service/terraform/aws/api_uri_rewrite.js
+++ b/service/terraform/aws/api_uri_rewrite.js
@@ -20,6 +20,13 @@ function handler(event) {
     var request = event.request;
     var incomingUri = request.uri;
 
+    // See if detailed logging is enabled
+    var debug = false
+    if ("cf_debug" in request.querystring) {
+         debug = true
+         delete request.querystring["cf_debug"]
+    }
+
     // Strip out any leading multiple slashies - registry-api#208
     while (incomingUri.indexOf("//") >= 0) {
         incomingUri = incomingUri.replace("//","/");
@@ -28,37 +35,48 @@ function handler(event) {
     // Put the URI back into the request now in case the rewrite doesn't happen
     request.uri = incomingUri
             
+    if (debug) console.log("incoming URI [" + incomingUri + "]")
+
     // continue with the rewrite only if "/api/search*" is first in the URI
     if (incomingUri.startsWith(TARGET_URI_PREFIX)) {
+
+        if (debug) console.log("incoming URI matches prefix [" + TARGET_URI_PREFIX + "]")
 
         // split the uri
         var uriParts = incomingUri.split("/");
 
         // at a minimum service, version and command are required, otherwise fall through w/o changes
         if (uriParts.length > CMD_IDX && uriParts[CMD_IDX].trim() != "") {
+            if (debug) console.log("incoming URI includes a command")
+
             // ensure that the API version is major version only
             var reqVer = uriParts[VER_IDX];
             var majorVer = reqVer.split(".")[0];
+            if (debug) console.log("revised request version [" + reqVer + "] to [" + majorVer + "]")
             
             // extract service and version which are placed in the HTTP header
             var resultHeader = uriParts[SVC_IDX] + "/" + majorVer;
+            if (debug) console.log("x-request-node header value [" + resultHeader + "]")
             
             // copy the rest of the request path to the new URI
             var newUri = "";
             for(var i = CMD_IDX; i < uriParts.length; i++) {
                 newUri += "/" + uriParts[i];
+                if (debug) console.log("appending to URI path [" + uriParts[i] + "]")
             }
 
             // set updated URI into request and set request node header
             request.uri = newUri;
             request.headers['x-request-node'] = { "value" : resultHeader };
-            console.log("incoming URI [" + incomingUri + "] rewritten to [" + newUri 
-                + "] & x-request-node [" + resultHeader + "]")
+            if (debug) {
+                console.log("incoming URI [" + incomingUri + "] rewritten to [" + newUri 
+                    + "] & x-request-node [" + resultHeader + "]")
+            }
         } else {
-            console.log("incoming URI [" + incomingUri + "] : no rewrite (no command)")
+            if (debug) console.log("incoming URI [" + incomingUri + "] : no rewrite (no command)")
         }
     } else {
-        console.log("incoming URI [" + incomingUri + "] : no rewrite (no prefix match)")
+        if (debug) console.log("incoming URI [" + incomingUri + "] : no rewrite (no prefix match)")
     }
 
     return request;


### PR DESCRIPTION
## 🗒️ Summary
Add logging messages to CF funcxtion which provide incoming URI and resulting rewrite (if applicable)

## ♻️ Related Issues
* https://github.com/NASA-PDS/cloud-tasks/issues/31

Log output will go to a cloudwatch log group /aws/cloudfront/function/api_uri_rewrite in the **us-east-1** region
