### PR TITLE
issue 260: add parsing exception handling

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
@@ -7,6 +7,8 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.antlr.v4.runtime.NoViableAltException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -114,6 +116,10 @@ public class SwaggerJavaTransmuter extends SwaggerJavaDeprecatedTransmuter
     } catch (NothingFoundException e) {
       log.warn("Could not find any matching reference(s) in database.");
       return new ResponseEntity<Object>(ErrorFactory.build(e, this.request), HttpStatus.NOT_FOUND);
+    } catch (NoViableAltException | ParseCancellationException e) {
+      log.warn("The given search string '" + parameters.getQuery() + "' cannot be parsed.");
+      return new ResponseEntity<Object>(ErrorFactory.build(new ParseCancellationException("The given search string '"
+          + parameters.getQuery() + "' cannot be parsed."), this.request), HttpStatus.BAD_REQUEST);
     } catch (UnknownGroupNameException e) {
       log.error("Group name not implemented", e);
       return new ResponseEntity<Object>(ErrorFactory.build(e, this.request),


### PR DESCRIPTION
## 🗒️ Summary
Another simple one line change to add more exception handling back to HTTP error codes and messaging.

## ⚙️ Test Data and/or Report
```
$ curl --request GET 'http://localhost:8080//classes/collections?q=%22%22'
{"request":"//classes/collections","message":"The given search string '""' cannot be parsed."}
```

**HOWEVER**

```
$ curl --request GET 'http://localhost:8080//classes/collections?q=""'
<!doctype html><html lang="en"><head><title>HTTP Status 400 – Bad Request</title><style type="text/css">body {font-family:Tahoma,Arial,sans-serif;} h1, h2, h3, b {color:white;background-color:#525D76;} h1 {font-size:22px;} h2 {font-size:16px;} h3 {font-size:14px;} p {font-size:12px;} a {color:black;} .line {height:1px;background-color:#525D76;border:none;}</style></head><body><h1>HTTP Status 400 – Bad Request</h1></body></html>n
```

**BECAUSE** the error is prior to registry-api in the apache code as the log shows which is a completely different problem:

```
java.lang.IllegalArgumentException: Invalid character found in the request target [//classes/collections?q="" ]. The valid characters are defined in RFC 7230 and RFC 3986
	at org.apache.coyote.http11.Http11InputBuffer.parseRequestLine(Http11InputBuffer.java:494) ~[tomcat-embed-core-9.0.63.jar:9.0.63]
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:271) ~[tomcat-embed-core-9.0.63.jar:9.0.63]
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65) ~[tomcat-embed-core-9.0.63.jar:9.0.63]
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:890) ~[tomcat-embed-core-9.0.63.jar:9.0.63]
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1743) ~[tomcat-embed-core-9.0.63.jar:9.0.63]
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49) ~[tomcat-embed-core-9.0.63.jar:9.0.63]
	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191) ~[tomcat-embed-core-9.0.63.jar:9.0.63]
	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659) ~[tomcat-embed-core-9.0.63.jar:9.0.63]
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) ~[tomcat-embed-core-9.0.63.jar:9.0.63]
	at java.base/java.lang.Thread.run(Thread.java:829) ~[na:na]
```

## ♻️ Related Issues
closes #260 
closes #255 
closes #252
closes #206 
