### PR TITLE
Invoke provenance script w/ --reset flag

### DIFF
--- a/support/provenance/provenance_driver.py
+++ b/support/provenance/provenance_driver.py
@@ -72,7 +72,7 @@ remotesStr = os.environ.get("PROV_REMOTES")
 if remotesStr is not None and remotesStr.strip() != '':
     remotesLists = json.loads(remotesStr)
 
-command = f'provenance.py -b {opensearch_endpoint} -l provenance.log -L DEBUG'
+command = f'provenance.py -b {opensearch_endpoint} -l provenance.log -L DEBUG --reset '
 if username is not None:
     command += f' -u {username} -p {passwd}'
 

--- a/support/provenance/provenance_driver.py
+++ b/support/provenance/provenance_driver.py
@@ -72,7 +72,7 @@ remotesStr = os.environ.get("PROV_REMOTES")
 if remotesStr is not None and remotesStr.strip() != '':
     remotesLists = json.loads(remotesStr)
 
-command = f'provenance.py -b {opensearch_endpoint} -l provenance.log -L DEBUG --reset '
+command = f'provenance.py -b {opensearch_endpoint} -l provenance.log -L DEBUG'
 if username is not None:
     command += f' -u {username} -p {passwd}'
 

--- a/support/provenance/terraform/ecs.tf
+++ b/support/provenance/terraform/ecs.tf
@@ -5,7 +5,7 @@ resource "aws_ecs_cluster" "ecs_cluster" {
   tags = {
     Alfa = var.node_name_abbr
     Bravo = var.venue
-    Charlie = "provenance"
+    Charlie = "registry-provenance"
   }
 }
 
@@ -21,7 +21,7 @@ resource "aws_cloudwatch_log_group" "pds-prov-log-group" {
   tags = {
     Alfa = var.node_name_abbr
     Bravo = var.venue
-    Charlie = "provenance"
+    Charlie = "registry-provenance"
   }
 }
 
@@ -43,7 +43,7 @@ resource "aws_ecs_service" "pds-provenance-service" {
   tags = {
     Alfa = var.node_name_abbr
     Bravo = var.venue
-    Charlie = "provenance"
+    Charlie = "registry-provenance"
   }
 }
 
@@ -99,7 +99,7 @@ EOF
   tags = {
     Alfa = var.node_name_abbr
     Bravo = var.venue
-    Charlie = "provenance"
+    Charlie = "registry-provenance"
   }
 }
 

--- a/support/provenance/terraform/ecs.tf
+++ b/support/provenance/terraform/ecs.tf
@@ -5,7 +5,7 @@ resource "aws_ecs_cluster" "ecs_cluster" {
   tags = {
     Alfa = var.node_name_abbr
     Bravo = var.venue
-    Charlie = "registry"
+    Charlie = "provenance"
   }
 }
 
@@ -21,7 +21,7 @@ resource "aws_cloudwatch_log_group" "pds-prov-log-group" {
   tags = {
     Alfa = var.node_name_abbr
     Bravo = var.venue
-    Charlie = "registry"
+    Charlie = "provenance"
   }
 }
 
@@ -36,14 +36,14 @@ resource "aws_ecs_service" "pds-provenance-service" {
 
   network_configuration {
     assign_public_ip = false
-    security_groups = var.aws_fg_security_groups
-    subnets = var.aws_fg_subnets
+    security_groups  = var.aws_fg_security_groups
+    subnets          = var.aws_fg_subnets
   }
 
   tags = {
     Alfa = var.node_name_abbr
     Bravo = var.venue
-    Charlie = "registry"
+    Charlie = "provenance"
   }
 }
 
@@ -99,7 +99,7 @@ EOF
   tags = {
     Alfa = var.node_name_abbr
     Bravo = var.venue
-    Charlie = "registry"
+    Charlie = "provenance"
   }
 }
 
@@ -108,3 +108,31 @@ data "aws_iam_role" "pds-task-execution-role" {
   name    = "am-ecs-task-execution"
 }
 
+resource "aws_scheduler_schedule" "provenance_schedule" {
+  name        = "pds-provenance-schedule"
+  description = "PDS scheduled provenance execution"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression = "rate(1 hour)"
+
+  target {
+    arn      = aws_ecs_cluster.ecs_cluster.arn
+    role_arn = "arn:aws:iam::445837347542:role/am-eventbridge-ecs"
+
+    ecs_parameters {
+      task_definition_arn     = aws_ecs_task_definition.pds-prov-ecs-task.arn
+      task_count              = 1
+      launch_type             = "FARGATE"
+      enable_execute_command  = false
+      enable_ecs_managed_tags = true
+
+      network_configuration {
+        subnets          = var.aws_fg_subnets
+        security_groups  = var.aws_fg_security_groups
+      }
+    }
+  }
+}

--- a/support/provenance/terraform/provider.tf
+++ b/support/provenance/terraform/provider.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = ">= 4.7"
+  version = "~> 4.7"
   region  = var.aws_region
   profile = var.aws_profile
 }

--- a/support/provenance/terraform/provider.tf
+++ b/support/provenance/terraform/provider.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 3.0"
+  version = ">= 4.7"
   region  = var.aws_region
   profile = var.aws_profile
 }

--- a/support/provenance/terraform/secrets.tf
+++ b/support/provenance/terraform/secrets.tf
@@ -15,7 +15,7 @@ resource "aws_ssm_parameter" "prov_endpoint_parameter" {
   tags = {
     Alfa = var.node_name_abbr
     Bravo = var.venue
-    Charlie = "provenance"
+    Charlie = "registry-provenance"
   }
 }
 
@@ -36,6 +36,6 @@ resource "aws_ssm_parameter" "prov_remotes_parameter" {
   tags = {
     Alfa = var.node_name_abbr
     Bravo = var.venue
-    Charlie = "provenance"
+    Charlie = "registry-provenance"
   }
 }

--- a/support/provenance/terraform/secrets.tf
+++ b/support/provenance/terraform/secrets.tf
@@ -15,7 +15,7 @@ resource "aws_ssm_parameter" "prov_endpoint_parameter" {
   tags = {
     Alfa = var.node_name_abbr
     Bravo = var.venue
-    Charlie = "registry"
+    Charlie = "provenance"
   }
 }
 
@@ -36,6 +36,6 @@ resource "aws_ssm_parameter" "prov_remotes_parameter" {
   tags = {
     Alfa = var.node_name_abbr
     Bravo = var.venue
-    Charlie = "registry"
+    Charlie = "provenance"
   }
 }

--- a/support/provenance/terraform/variables.tf
+++ b/support/provenance/terraform/variables.tf
@@ -63,3 +63,7 @@ variable "aws_ecr_pull_policy_arn" {
   description = "ARN for the ECR pull policy"
   default = "arn:aws:iam::aws:policy/service-role/AWSAppRunnerServicePolicyForECRAccess"
 }
+
+variable "aws_eventbridge_role_arn" {
+  description = "Role for eventbridge execution"
+}


### PR DESCRIPTION
## 🗒️ Summary
Add --reset flag to provenance execution in order to force recalculation of all document histories.

This PR also incorporates terraform changes to incorporate creation of EventBridge scheduler components.
