### PR TITLE
revert erroneous change to default server port

### DIFF
--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 server.contextPath=/
-server.port=8081
+server.port=8080
 server.use-forward-headers=true
 
 springdoc.api-docs.path=/api-docs


### PR DESCRIPTION
## 🗒️ Summary
Reverts change to default server port.  Presumably this was not intentional as the documentation still specifies 8080

No related issue