### PR TITLE
registry-155 - Registry multi-tenancy

### DIFF
--- a/model/swagger.yml
+++ b/model/swagger.yml
@@ -80,6 +80,7 @@ paths:
         - $ref: "#/components/parameters/Query"
         - $ref: "#/components/parameters/Sort"
         - $ref: "#/components/parameters/Start"
+        - $ref: "#/components/parameters/Node"
   /classes/{class}/{identifier}/members:
     get:
       tags:
@@ -105,6 +106,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
   /classes/{class}/{identifier}/members/{versions}:
     get:
       tags:
@@ -131,6 +133,7 @@ paths:
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
       - $ref: "#/components/parameters/Versions"
+      - $ref: "#/components/parameters/Node"
   /classes/{class}/{identifier}/members/members:
     get:
       tags:
@@ -156,6 +159,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
   /classes/{class}/{identifier}/members/members/{versions}:
     get:
       tags:
@@ -182,6 +186,7 @@ paths:
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
       - $ref: "#/components/parameters/Versions"
+      - $ref: "#/components/parameters/Node"
   /classes/{class}/{identifier}/member-of:
     get:
       tags:
@@ -207,6 +212,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
   /classes/{class}/{identifier}/member-of/{versions}:
     get:
       tags:
@@ -233,6 +239,7 @@ paths:
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
       - $ref: "#/components/parameters/Versions"
+      - $ref: "#/components/parameters/Node"
   /classes/{class}/{identifier}/member-of/member-of:
     get:
       tags:
@@ -258,6 +265,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
   /classes/{class}/{identifier}/member-of/member-of/{versions}:
     get:
       tags:
@@ -284,6 +292,7 @@ paths:
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
       - $ref: "#/components/parameters/Versions"
+      - $ref: "#/components/parameters/Node"
 
   /products:
     get:
@@ -310,6 +319,7 @@ paths:
       - $ref: "#/components/parameters/Query"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /products/{identifier}:
     get:
@@ -332,6 +342,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/Fields"
       - $ref: "#/components/parameters/Identifier"
+      - $ref: "#/components/parameters/Node"
   /products/{identifier}/latest:
     get:
       tags:
@@ -353,6 +364,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/Fields"
       - $ref: "#/components/parameters/Identifier"
+      - $ref: "#/components/parameters/Node"
   /products/{identifier}/all:
     get:
       tags:
@@ -379,6 +391,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
   /products/{identifier}/members:
     get:
       tags:
@@ -403,6 +416,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
   /products/{identifier}/members/{versions}:
     get:
       tags:
@@ -428,6 +442,7 @@ paths:
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
       - $ref: "#/components/parameters/Versions"
+      - $ref: "#/components/parameters/Node"
   /products/{identifier}/members/members:
     get:
       tags:
@@ -452,6 +467,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
   /products/{identifier}/members/members/{versions}:
     get:
       tags:
@@ -477,6 +493,7 @@ paths:
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
       - $ref: "#/components/parameters/Versions"
+      - $ref: "#/components/parameters/Node"
   /products/{identifier}/member-of:
     get:
       tags:
@@ -501,6 +518,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
   /products/{identifier}/member-of/{versions}:
     get:
       tags:
@@ -526,6 +544,7 @@ paths:
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
       - $ref: "#/components/parameters/Versions"
+      - $ref: "#/components/parameters/Node"
   /products/{identifier}/member-of/member-of:
     get:
       tags:
@@ -550,6 +569,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
   /products/{identifier}/member-of/member-of/{versions}:
     get:
       tags:
@@ -575,6 +595,7 @@ paths:
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
       - $ref: "#/components/parameters/Versions"
+      - $ref: "#/components/parameters/Node"
 
 # begin deprecated: this is the older API that is clutter
   /bundles:
@@ -601,6 +622,7 @@ paths:
       - $ref: "#/components/parameters/Query"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /bundles/{identifier}:
     get:
@@ -622,6 +644,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/Fields"
       - $ref: "#/components/parameters/Identifier"
+      - $ref: "#/components/parameters/Node"
 
   /bundles/{identifier}/all:
     get:
@@ -646,6 +669,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /bundles/{identifier}/latest:
     get:
@@ -667,6 +691,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/Fields"
       - $ref: "#/components/parameters/Identifier"
+      - $ref: "#/components/parameters/Node"
 
   /bundles/{identifier}/collections:
     get:
@@ -691,6 +716,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /bundles/{identifier}/collections/all:
     get:
@@ -715,6 +741,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /bundles/{identifier}/collections/latest:
     get:
@@ -739,6 +766,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /bundles/{identifier}/products:
     get:
@@ -763,6 +791,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /collections:
     get:
@@ -788,6 +817,7 @@ paths:
       - $ref: "#/components/parameters/Query"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /collections/{identifier}:
     get:
@@ -809,6 +839,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/Fields"
       - $ref: "#/components/parameters/Identifier"
+      - $ref: "#/components/parameters/Node"
 
   /collections/{identifier}/all:
     get:
@@ -833,6 +864,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /collections/{identifier}/latest:
     get:
@@ -854,6 +886,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/Fields"
       - $ref: "#/components/parameters/Identifier"
+      - $ref: "#/components/parameters/Node"
 
   /collections/{identifier}/bundles:
     get:
@@ -878,6 +911,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /collections/{identifier}/products:
     get:
@@ -902,6 +936,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /collections/{identifier}/products/all:
     get:
@@ -926,6 +961,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /collections/{identifier}/products/latest:
     get:
@@ -950,6 +986,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /products/{identifier}/bundles:
     get:
@@ -974,6 +1011,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /products/{identifier}/bundles/all:
     get:
@@ -998,6 +1036,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /products/{identifier}/bundles/latest:
     get:
@@ -1022,6 +1061,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /products/{identifier}/collections:
     get:
@@ -1046,6 +1086,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /products/{identifier}/collections/all:
     get:
@@ -1070,6 +1111,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 
   /products/{identifier}/collections/latest:
     get:
@@ -1094,6 +1136,7 @@ paths:
       - $ref: "#/components/parameters/Limit"
       - $ref: "#/components/parameters/Sort"
       - $ref: "#/components/parameters/Start"
+      - $ref: "#/components/parameters/Node"
 # end deprecated: for easy clutter removal
 
 components:
@@ -1211,6 +1254,18 @@ components:
       schema:
         type: string
         enum: [all,latest]
+    Node:
+      name: node
+      in: query
+      description: |
+        syntax: node=sbn
+
+        behavior: Specific node id with which to filter returned results
+
+        note: If omitted, no node filtering is applied
+      required: false
+      schema:
+        type: string
   responses:
     Error:
       description: Unsuccessful request
@@ -1362,6 +1417,11 @@ components:
           type: array
           items:
             type: string
+          xml:
+            prefix: 'pds_api'
+            namespace: 'http://pds.nasa.gov/api'
+        node:
+          type: string
           xml:
             prefix: 'pds_api'
             namespace: 'http://pds.nasa.gov/api'

--- a/service/src/main/java/gov/nasa/pds/api/registry/RequestBuildContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/RequestBuildContext.java
@@ -10,4 +10,6 @@ public interface RequestBuildContext {
   public List<String> getFields(); // must not return null but an empty list
 
   public GroupConstraint getPresetCriteria(); // must not return null but an empty list
+
+  public String getNode(); // may return null
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/UserContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/UserContext.java
@@ -22,4 +22,6 @@ public interface UserContext extends LidvidsContext {
   public List<String> getSort();
 
   public String getVersion();
+
+  public String getNode();
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaBaseTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaBaseTransmuter.java
@@ -15,31 +15,34 @@ abstract class SwaggerJavaBaseTransmuter {
 
   public ResponseEntity<Object> groupReferencingId(String group, String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     return this.processs(new GroupReferencingId(), new URIParameters().setGroup(group)
-        .setIdentifier(identifier).setFields(fields).setLimit(limit).setSort(sort).setStart(start));
+        .setIdentifier(identifier).setFields(fields).setLimit(limit).setSort(sort).setStart(start)
+	.setNode(node));
   }
 
   public ResponseEntity<Object> groupReferencingIdVers(String group, String identifier,
       String versions, @Valid List<String> fields, @Min(0) @Valid Integer limit,
-      @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Valid List<String> sort, @Min(0) @Valid Integer start, @Valid String node) {
     return this.processs(new GroupReferencingId(),
         new URIParameters().setGroup(group).setIdentifier(identifier).setVersion(versions)
-            .setFields(fields).setLimit(limit).setSort(sort).setStart(start));
+            .setFields(fields).setLimit(limit).setSort(sort).setStart(start)
+	    .setNode(node));
   }
 
   public ResponseEntity<Object> idReferencingGroup(String group, String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     return this.processs(new IdReferencingGroup(), new URIParameters().setGroup(group)
-        .setIdentifier(identifier).setFields(fields).setLimit(limit).setSort(sort).setStart(start));
+        .setIdentifier(identifier).setFields(fields).setLimit(limit).setSort(sort).setStart(start)
+	.setNode(node));
   }
 
   public ResponseEntity<Object> idReferencingGroupVers(String group, String identifier,
       String versions, @Valid List<String> fields, @Min(0) @Valid Integer limit,
-      @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Valid List<String> sort, @Min(0) @Valid Integer start, @Valid String node) {
     return this.processs(new IdReferencingGroup(),
         new URIParameters().setGroup(group).setIdentifier(identifier).setVersion(versions)
-            .setFields(fields).setLimit(limit).setSort(sort).setStart(start));
+            .setFields(fields).setLimit(limit).setSort(sort).setStart(start).setNode(node));
   }
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaClassesTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaClassesTransmuter.java
@@ -22,85 +22,89 @@ abstract class SwaggerJavaClassesTransmuter extends SwaggerJavaBaseTransmuter
   @Override
   public ResponseEntity<Object> classList(String propertyClass, @Valid List<String> fields,
       @Valid List<String> keywords, @Min(0) @Valid Integer limit, @Valid String q,
-      @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Valid List<String> sort, @Min(0) @Valid Integer start, @Valid String node) {
     return this.processs(new Standard(),
         new URIParameters().setGroup(propertyClass).setFields(fields).setKeywords(keywords)
-            .setLimit(limit).setQuery(q).setSort(sort).setStart(start));
+            .setLimit(limit).setQuery(q).setSort(sort).setStart(start).setNode(node));
   }
 
   @Override
   public ResponseEntity<Object> classMemberOf(String propertyClass, String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     return this.processs(new Member(false, false),
         new URIParameters().setGroup(propertyClass).setIdentifier(identifier).setFields(fields)
-            .setLimit(limit).setSort(sort).setStart(start).setVerifyClassAndId(true));
+            .setLimit(limit).setSort(sort).setStart(start).setVerifyClassAndId(true)
+	    .setNode(node));
   }
 
   @Override
   public ResponseEntity<Object> classMemberOfOf(String propertyClass, String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     return this.processs(new Member(false, true),
         new URIParameters().setGroup(propertyClass).setIdentifier(identifier).setFields(fields)
-            .setLimit(limit).setSort(sort).setStart(start).setVerifyClassAndId(true));
+            .setLimit(limit).setSort(sort).setStart(start).setVerifyClassAndId(true)
+	    .setNode(node));
   }
 
   @Override
   public ResponseEntity<Object> classMemberOfOfVers(String propertyClass, String identifier,
       String versions, @Valid List<String> fields, @Min(0) @Valid Integer limit,
-      @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Valid List<String> sort, @Min(0) @Valid Integer start, @Valid String node) {
     return this.processs(new Member(false, true),
         new URIParameters().setGroup(propertyClass).setIdentifier(identifier).setFields(fields)
             .setLimit(limit).setSort(sort).setStart(start).setVerifyClassAndId(true)
-            .setVersion(versions));
+            .setVersion(versions).setNode(node));
   }
 
   @Override
   public ResponseEntity<Object> classMemberOfVers(String propertyClass, String identifier,
       String versions, @Valid List<String> fields, @Min(0) @Valid Integer limit,
-      @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Valid List<String> sort, @Min(0) @Valid Integer start, @Valid String node) {
     return this.processs(new Member(false, false),
         new URIParameters().setGroup(propertyClass).setIdentifier(identifier).setFields(fields)
             .setLimit(limit).setSort(sort).setStart(start).setVerifyClassAndId(true)
-            .setVersion(versions));
+            .setVersion(versions).setNode(node));
   }
 
   @Override
   public ResponseEntity<Object> classMembers(String propertyClass, String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     return this.processs(new Member(true, false),
         new URIParameters().setGroup(propertyClass).setIdentifier(identifier).setFields(fields)
-            .setLimit(limit).setSort(sort).setStart(start).setVerifyClassAndId(true));
+            .setLimit(limit).setSort(sort).setStart(start).setVerifyClassAndId(true)
+	    .setNode(node));
   }
 
   @Override
   public ResponseEntity<Object> classMembersMembers(String propertyClass, String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     return this.processs(new Member(true, true),
         new URIParameters().setGroup(propertyClass).setIdentifier(identifier).setFields(fields)
-            .setLimit(limit).setSort(sort).setStart(start).setVerifyClassAndId(true));
+            .setLimit(limit).setSort(sort).setStart(start).setVerifyClassAndId(true)
+	    .setNode(node));
   }
 
   @Override
   public ResponseEntity<Object> classMembersMembersVers(String propertyClass, String identifier,
       String versions, @Valid List<String> fields, @Min(0) @Valid Integer limit,
-      @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Valid List<String> sort, @Min(0) @Valid Integer start, @Valid String node) {
     return this.processs(new Member(true, true),
         new URIParameters().setGroup(propertyClass).setIdentifier(identifier).setFields(fields)
             .setLimit(limit).setSort(sort).setStart(start).setVerifyClassAndId(true)
-            .setVersion(versions));
+            .setVersion(versions).setNode(node));
   }
 
   @Override
   public ResponseEntity<Object> classMembersVers(String propertyClass, String identifier,
       String versions, @Valid List<String> fields, @Min(0) @Valid Integer limit,
-      @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Valid List<String> sort, @Min(0) @Valid Integer start, @Valid String node) {
     return this.processs(new Member(true, false),
         new URIParameters().setGroup(propertyClass).setIdentifier(identifier).setFields(fields)
             .setLimit(limit).setSort(sort).setStart(start).setVerifyClassAndId(true)
-            .setVersion(versions));
+            .setVersion(versions).setNode(node));
   }
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaDeprecatedTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaDeprecatedTransmuter.java
@@ -14,153 +14,174 @@ abstract class SwaggerJavaDeprecatedTransmuter extends SwaggerJavaProductsTransm
   @Override
   public ResponseEntity<Object> bundleList(@Valid List<String> fields, @Valid List<String> keywords,
       @Min(0) @Valid Integer limit, @Valid String q, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
-    return super.classList("bundles", fields, keywords, limit, q, sort, start);
+      @Min(0) @Valid Integer start, @Valid String node) {
+    return super.classList("bundles", fields, keywords, limit, q, sort, start, node);
   }
 
   @Override
-  public ResponseEntity<Object> bundlesLidvid(String identifier, @Valid List<String> fields) {
+  public ResponseEntity<Object> bundlesLidvid(String identifier, @Valid List<String> fields,
+      @Valid String node) {
     return this.processs(new Standard(), new URIParameters().setGroup("bundles")
-        .setIdentifier(identifier).setFields(fields).setVerifyClassAndId(true));
+        .setIdentifier(identifier).setFields(fields).setVerifyClassAndId(true)
+        .setNode(node));
   }
 
   @Override
   public ResponseEntity<Object> bundlesLidvidAll(String identifier, @Valid List<String> fields,
-      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+      @Valid String node) {
     return this.processs(new Standard(),
         new URIParameters().setGroup("bundles").setIdentifier(identifier).setFields(fields)
-            .setVerifyClassAndId(true).setVersion(ProductVersionSelector.ALL));
+            .setVerifyClassAndId(true).setVersion(ProductVersionSelector.ALL)
+            .setNode(node));
   }
 
   @Override
   public ResponseEntity<Object> bundlesLidvidCollections(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
-    return this.classMembers("bundles", identifier, fields, limit, sort, start);
+      @Min(0) @Valid Integer start, @Valid String node) {
+    return this.classMembers("bundles", identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> bundlesLidvidCollectionsAll(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
-    return this.classMembersVers("bundles", identifier, "all", fields, limit, sort, start);
+      @Min(0) @Valid Integer start, @Valid String node) {
+    return this.classMembersVers("bundles", identifier, "all", fields, limit, sort, start,
+      node);
   }
 
   @Override
   public ResponseEntity<Object> bundlesLidvidCollectionsLatest(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
-    return this.classMembersVers("bundles", identifier, "latest", fields, limit, sort, start);
+      @Min(0) @Valid Integer start, @Valid String node) {
+    return this.classMembersVers("bundles", identifier, "latest", fields, limit, sort, start,
+      node);
   }
 
   @Override
-  public ResponseEntity<Object> bundlesLidvidLatest(String identifier, @Valid List<String> fields) {
+  public ResponseEntity<Object> bundlesLidvidLatest(String identifier, @Valid List<String> fields,
+      @Valid String node) {
     return this.processs(new Standard(),
         new URIParameters().setGroup("bundles").setIdentifier(identifier).setFields(fields)
-            .setVerifyClassAndId(true).setVersion(ProductVersionSelector.LATEST));
+            .setVerifyClassAndId(true).setVersion(ProductVersionSelector.LATEST)
+            .setNode(node));
   }
 
   @Override
   public ResponseEntity<Object> bundlesLidvidProducts(String identifier, @Valid List<String> fields,
-      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
-    return this.classMembersMembers("bundles", identifier, fields, limit, sort, start);
+      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+      @Valid String node) {
+    return this.classMembersMembers("bundles", identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> collectionList(@Valid List<String> fields,
       @Valid List<String> keywords, @Min(0) @Valid Integer limit, @Valid String q,
-      @Valid List<String> sort, @Min(0) @Valid Integer start) {
-    return super.classList("collections", fields, keywords, limit, q, sort, start);
+      @Valid List<String> sort, @Min(0) @Valid Integer start, @Valid String node) {
+    return super.classList("collections", fields, keywords, limit, q, sort, start, node);
   }
 
   @Override
-  public ResponseEntity<Object> collectionsLidvid(String identifier, @Valid List<String> fields) {
+  public ResponseEntity<Object> collectionsLidvid(String identifier, @Valid List<String> fields,
+        @Valid String node) {
     return this.processs(new Standard(), new URIParameters().setGroup("collections")
-        .setIdentifier(identifier).setFields(fields).setVerifyClassAndId(true));
+        .setIdentifier(identifier).setFields(fields).setVerifyClassAndId(true)
+        .setNode(node));
   }
 
   @Override
   public ResponseEntity<Object> collectionsLidvidAll(String identifier, @Valid List<String> fields,
-      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+      @Valid String node) {
     return this.processs(new Standard(),
         new URIParameters().setGroup("collections").setIdentifier(identifier).setFields(fields)
-            .setVerifyClassAndId(true).setVersion(ProductVersionSelector.ALL));
+            .setVerifyClassAndId(true).setVersion(ProductVersionSelector.ALL)
+            .setNode(node));
   }
 
   @Override
   public ResponseEntity<Object> collectionsLidvidBundles(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
-    return this.classMemberOf("collections", identifier, fields, limit, sort, start);
+      @Min(0) @Valid Integer start, @Valid String node) {
+    return this.classMemberOf("collections", identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> collectionsLidvidLatest(String identifier,
-      @Valid List<String> fields) {
+      @Valid List<String> fields, @Valid String node) {
     return this.processs(new Standard(),
         new URIParameters().setGroup("collections").setIdentifier(identifier).setFields(fields)
-            .setVerifyClassAndId(true).setVersion(ProductVersionSelector.LATEST));
+            .setVerifyClassAndId(true).setVersion(ProductVersionSelector.LATEST)
+            .setNode(node));
   }
 
   @Override
   public ResponseEntity<Object> collectionsLidvidProducts(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
-    return this.classMembers("collections", identifier, fields, limit, sort, start);
+      @Min(0) @Valid Integer start, @Valid String node) {
+    return this.classMembers("collections", identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> collectionsLidvidProductsAll(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
-    return this.classMembersVers("collections", identifier, "all", fields, limit, sort, start);
+      @Min(0) @Valid Integer start, @Valid String node) {
+    return this.classMembersVers("collections", identifier, "all", fields, limit, sort, start,
+      node);
   }
 
   @Override
   public ResponseEntity<Object> collectionsLidvidProductsLatest(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
-    return this.classMembersVers("collections", identifier, "latest", fields, limit, sort, start);
+      @Min(0) @Valid Integer start, @Valid String node) {
+    return this.classMembersVers("collections", identifier, "latest", fields, limit, sort, 
+      start, node);
   }
 
   @Override
   public ResponseEntity<Object> productsLidividBundlesAll(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
-    return this.classMemberOfOfVers("any", identifier, "all", fields, limit, sort, start);
+      @Min(0) @Valid Integer start, @Valid String node) {
+    return this.classMemberOfOfVers("any", identifier, "all", fields, limit, sort, start,
+      node);
   }
 
   @Override
   public ResponseEntity<Object> productsLidvidBundles(String identifier, @Valid List<String> fields,
-      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
-    return this.classMemberOfOf("any", identifier, fields, limit, sort, start);
+      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+      @Valid String node) {
+    return this.classMemberOfOf("any", identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productsLidvidBundlesLatest(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
-    return this.classMemberOfOfVers("any", identifier, "latest", fields, limit, sort, start);
+      @Min(0) @Valid Integer start, @Valid String node) {
+    return this.classMemberOfOfVers("any", identifier, "latest", fields, limit, sort, start,
+      node);
   }
 
   @Override
   public ResponseEntity<Object> productsLidvidCollections(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
-    return this.classMemberOf("any", identifier, fields, limit, sort, start);
+      @Min(0) @Valid Integer start, @Valid String node) {
+    return this.classMemberOf("any", identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productsLidvidCollectionsAll(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
-    return this.classMemberOfVers("any", identifier, "all", fields, limit, sort, start);
+      @Min(0) @Valid Integer start, @Valid String node) {
+    return this.classMemberOfVers("any", identifier, "all", fields, limit, sort, start,
+      node);
   }
 
   @Override
   public ResponseEntity<Object> productsLidvidCollectionsLatest(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
-    return this.classMemberOfVers("any", identifier, "latest", fields, limit, sort, start);
+      @Min(0) @Valid Integer start, @Valid String node) {
+    return this.classMemberOfVers("any", identifier, "latest", fields, limit, sort, start,
+      node);
   }
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaProductsTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaProductsTransmuter.java
@@ -20,82 +20,95 @@ abstract class SwaggerJavaProductsTransmuter extends SwaggerJavaClassesTransmute
 
 	@Override
 	public ResponseEntity<Object> productList(@Valid List<String> fields, @Valid List<String> keywords,
-			@Min(0) @Valid Integer limit, @Valid String q, @Valid List<String> sort, @Min(0) @Valid Integer start) {
-		return super.classList("any", fields, keywords, limit, q, sort, start);
+			@Min(0) @Valid Integer limit, @Valid String q, @Valid List<String> sort, 
+                        @Min(0) @Valid Integer start, @Valid String node) {
+		return super.classList("any", fields, keywords, limit, q, sort, start, node);
 	}
 
 	@Override
 	public ResponseEntity<Object> productMemberOf(String identifier, @Valid List<String> fields,
-			@Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
-		return this.processs(new Member(false, false), new URIParameters().setIdentifier(identifier).setFields(fields)
-				.setLimit(limit).setSort(sort).setStart(start));
+			@Min(0) @Valid Integer limit, @Valid List<String> sort, 
+                        @Min(0) @Valid Integer start, @Valid String node) {
+		return this.processs(new Member(false, false), new URIParameters().setIdentifier(identifier)
+                    .setFields(fields).setLimit(limit).setSort(sort).setStart(start).setNode(node));
 	}
 
 	@Override
 	public ResponseEntity<Object> productMemberOfOf(String identifier, @Valid List<String> fields,
-			@Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
-		return this.processs(new Member(false, true), new URIParameters().setIdentifier(identifier).setFields(fields)
-				.setLimit(limit).setSort(sort).setStart(start));
+			@Min(0) @Valid Integer limit, @Valid List<String> sort, 
+                        @Min(0) @Valid Integer start, @Valid String node) {
+		return this.processs(new Member(false, true), new URIParameters().setIdentifier(identifier)
+                    .setFields(fields).setLimit(limit).setSort(sort).setStart(start).setNode(node));
 	}
 
 	@Override
-	public ResponseEntity<Object> productMemberOfOfVers(String identifier, String versions, @Valid List<String> fields,
-			@Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
-		return this.processs(new Member(false, true), new URIParameters().setIdentifier(identifier).setFields(fields)
-				.setLimit(limit).setSort(sort).setStart(start).setVersion(versions));
+	public ResponseEntity<Object> productMemberOfOfVers(String identifier, String versions, 
+                        @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort, 
+                        @Min(0) @Valid Integer start, @Valid String node) {
+		return this.processs(new Member(false, true), new URIParameters().setIdentifier(identifier)
+		    .setFields(fields).setLimit(limit).setSort(sort).setStart(start).setVersion(versions)
+		    .setNode(node));
 	}
 
 	@Override
 	public ResponseEntity<Object> productMemberOfVers(String identifier, String versions, @Valid List<String> fields,
-			@Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+			@Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+                        @Valid String node) {
 		return this.processs(new Member(false, false), new URIParameters().setIdentifier(identifier).setFields(fields)
-				.setLimit(limit).setSort(sort).setStart(start).setVersion(versions));
+				.setLimit(limit).setSort(sort).setStart(start).setVersion(versions).setNode(node));
 	}
 
 	@Override
 	public ResponseEntity<Object> productMembers(String identifier, @Valid List<String> fields,
-			@Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+			@Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+			@Valid String node) {
 		return this.processs(new Member(true, false), new URIParameters().setIdentifier(identifier).setFields(fields)
-				.setLimit(limit).setSort(sort).setStart(start));
+				.setLimit(limit).setSort(sort).setStart(start).setNode(node));
 	}
 
 	@Override
 	public ResponseEntity<Object> productMembersMembers(String identifier, @Valid List<String> fields,
-			@Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+			@Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+			@Valid String node) {
 		return this.processs(new Member(true, true), new URIParameters().setIdentifier(identifier).setFields(fields)
-				.setLimit(limit).setSort(sort).setStart(start));
+				.setLimit(limit).setSort(sort).setStart(start).setNode(node));
 	}
 
 	@Override
 	public ResponseEntity<Object> productMembersMembersVers(String identifier, String versions,
 			@Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-			@Min(0) @Valid Integer start) {
+			@Min(0) @Valid Integer start, @Valid String node) {
 		return this.processs(new Member(true, true), new URIParameters().setIdentifier(identifier).setFields(fields)
-				.setLimit(limit).setSort(sort).setStart(start).setVersion(versions));
+		    .setLimit(limit).setSort(sort).setStart(start).setVersion(versions).setNode(node));
 	}
 
 	@Override
 	public ResponseEntity<Object> productMembersVers(String identifier, String versions, @Valid List<String> fields,
-			@Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+			@Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+			@Valid String node) {
 		return this.processs(new Member(true, false), new URIParameters().setIdentifier(identifier).setFields(fields)
-				.setLimit(limit).setSort(sort).setStart(start).setVersion(versions));
+		    .setLimit(limit).setSort(sort).setStart(start).setVersion(versions).setNode(node));
 	}
 
 	@Override
-	public ResponseEntity<Object> selectByLidvid(String identifier, @Valid List<String> fields) {
-		return this.processs(new Standard(), new URIParameters().setIdentifier(identifier).setFields(fields));
+	public ResponseEntity<Object> selectByLidvid(String identifier, @Valid List<String> fields, @Valid String node) {
+		return this.processs(new Standard(), new URIParameters().setIdentifier(identifier).setFields(fields)
+		    .setNode(node));
 	}
 
 	@Override
 	public ResponseEntity<Object> selectByLidvidAll(String identifier, @Valid List<String> fields,
-			@Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+			@Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+			@Valid String node) {
 		return this.processs(new Standard(), new URIParameters().setIdentifier(identifier).setFields(fields)
-				.setLimit(limit).setSort(sort).setStart(start).setVersion(ProductVersionSelector.ALL));
+		    .setLimit(limit).setSort(sort).setStart(start).setVersion(ProductVersionSelector.ALL)
+		    .setNode(node));
 	}
 
 	@Override
-	public ResponseEntity<Object> selectByLidvidLatest(String identifier, @Valid List<String> fields) {
+	public ResponseEntity<Object> selectByLidvidLatest(String identifier, @Valid List<String> fields,
+			@Valid String node) {
 		return this.processs(new Standard(), new URIParameters().setIdentifier(identifier).setFields(fields)
-				.setVersion(ProductVersionSelector.LATEST));
+		    .setVersion(ProductVersionSelector.LATEST).setNode(node));
 	}
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
@@ -145,254 +145,267 @@ public class SwaggerJavaTransmuter extends SwaggerJavaDeprecatedTransmuter
   @Override
   public ResponseEntity<Object> bundleList(@Valid List<String> fields, @Valid List<String> keywords,
       @Min(0) @Valid Integer limit, @Valid String q, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start,
+      @Valid String node) {
     // TODO Auto-generated method stub
-    return super.bundleList(fields, keywords, limit, q, sort, start);
+    return super.bundleList(fields, keywords, limit, q, sort, start, node);
   }
 
   @Override
-  public ResponseEntity<Object> bundlesLidvid(String identifier, @Valid List<String> fields) {
+  public ResponseEntity<Object> bundlesLidvid(String identifier, @Valid List<String> fields, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.bundlesLidvid(identifier, fields);
+    return super.bundlesLidvid(identifier, fields, node);
   }
 
   @Override
   public ResponseEntity<Object> bundlesLidvidAll(String identifier, @Valid List<String> fields,
-      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start, 
+      @Valid String node) {
     // TODO Auto-generated method stub
-    return super.bundlesLidvidAll(identifier, fields, limit, sort, start);
+    return super.bundlesLidvidAll(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> bundlesLidvidCollections(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.bundlesLidvidCollections(identifier, fields, limit, sort, start);
+    return super.bundlesLidvidCollections(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> bundlesLidvidCollectionsAll(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.bundlesLidvidCollectionsAll(identifier, fields, limit, sort, start);
+    return super.bundlesLidvidCollectionsAll(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> bundlesLidvidCollectionsLatest(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.bundlesLidvidCollectionsLatest(identifier, fields, limit, sort, start);
+    return super.bundlesLidvidCollectionsLatest(identifier, fields, limit, sort, start, node);
   }
 
   @Override
-  public ResponseEntity<Object> bundlesLidvidLatest(String identifier, @Valid List<String> fields) {
+  public ResponseEntity<Object> bundlesLidvidLatest(String identifier, @Valid List<String> fields, 
+      @Valid String node) {
     // TODO Auto-generated method stub
-    return super.bundlesLidvidLatest(identifier, fields);
+    return super.bundlesLidvidLatest(identifier, fields, node);
   }
 
   @Override
   public ResponseEntity<Object> bundlesLidvidProducts(String identifier, @Valid List<String> fields,
-      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+      @Valid String node) {
     // TODO Auto-generated method stub
-    return super.bundlesLidvidProducts(identifier, fields, limit, sort, start);
+    return super.bundlesLidvidProducts(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> collectionList(@Valid List<String> fields,
       @Valid List<String> keywords, @Min(0) @Valid Integer limit, @Valid String q,
-      @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Valid List<String> sort, @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.collectionList(fields, keywords, limit, q, sort, start);
+    return super.collectionList(fields, keywords, limit, q, sort, start, node);
   }
 
   @Override
-  public ResponseEntity<Object> collectionsLidvid(String identifier, @Valid List<String> fields) {
+  public ResponseEntity<Object> collectionsLidvid(String identifier, @Valid List<String> fields,
+      @Valid String node) {
     // TODO Auto-generated method stub
-    return super.collectionsLidvid(identifier, fields);
+    return super.collectionsLidvid(identifier, fields, node);
   }
 
   @Override
   public ResponseEntity<Object> collectionsLidvidAll(String identifier, @Valid List<String> fields,
-      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+      @Valid String node) {
     // TODO Auto-generated method stub
-    return super.collectionsLidvidAll(identifier, fields, limit, sort, start);
+    return super.collectionsLidvidAll(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> collectionsLidvidBundles(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.collectionsLidvidBundles(identifier, fields, limit, sort, start);
+    return super.collectionsLidvidBundles(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> collectionsLidvidLatest(String identifier,
-      @Valid List<String> fields) {
+      @Valid List<String> fields, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.collectionsLidvidLatest(identifier, fields);
+    return super.collectionsLidvidLatest(identifier, fields, node);
   }
 
   @Override
   public ResponseEntity<Object> collectionsLidvidProducts(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.collectionsLidvidProducts(identifier, fields, limit, sort, start);
+    return super.collectionsLidvidProducts(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> collectionsLidvidProductsAll(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.collectionsLidvidProductsAll(identifier, fields, limit, sort, start);
+    return super.collectionsLidvidProductsAll(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> collectionsLidvidProductsLatest(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.collectionsLidvidProductsLatest(identifier, fields, limit, sort, start);
+    return super.collectionsLidvidProductsLatest(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productList(@Valid List<String> fields,
       @Valid List<String> keywords, @Min(0) @Valid Integer limit, @Valid String q,
-      @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Valid List<String> sort, @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.productList(fields, keywords, limit, q, sort, start);
+    return super.productList(fields, keywords, limit, q, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productsLidividBundlesAll(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.productsLidividBundlesAll(identifier, fields, limit, sort, start);
+    return super.productsLidividBundlesAll(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productsLidvidBundles(String identifier, @Valid List<String> fields,
-      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+      @Valid String node) {
     // TODO Auto-generated method stub
-    return super.productsLidvidBundles(identifier, fields, limit, sort, start);
+    return super.productsLidvidBundles(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productsLidvidBundlesLatest(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.productsLidvidBundlesLatest(identifier, fields, limit, sort, start);
+    return super.productsLidvidBundlesLatest(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productsLidvidCollections(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.productsLidvidCollections(identifier, fields, limit, sort, start);
+    return super.productsLidvidCollections(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productsLidvidCollectionsAll(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.productsLidvidCollectionsAll(identifier, fields, limit, sort, start);
+    return super.productsLidvidCollectionsAll(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productsLidvidCollectionsLatest(String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.productsLidvidCollectionsLatest(identifier, fields, limit, sort, start);
+    return super.productsLidvidCollectionsLatest(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productMemberOf(String identifier, @Valid List<String> fields,
-      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+      @Valid String node) {
     // TODO Auto-generated method stub
-    return super.productMemberOf(identifier, fields, limit, sort, start);
+    return super.productMemberOf(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productMemberOfOf(String identifier, @Valid List<String> fields,
-      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+      @Valid String node) {
     // TODO Auto-generated method stub
-    return super.productMemberOfOf(identifier, fields, limit, sort, start);
+    return super.productMemberOfOf(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productMemberOfOfVers(String identifier, String versions,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.productMemberOfOfVers(identifier, versions, fields, limit, sort, start);
+    return super.productMemberOfOfVers(identifier, versions, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productMemberOfVers(String identifier, String versions,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.productMemberOfVers(identifier, versions, fields, limit, sort, start);
+    return super.productMemberOfVers(identifier, versions, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productMembers(String identifier, @Valid List<String> fields,
-      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+      @Valid String node) {
     // TODO Auto-generated method stub
-    return super.productMembers(identifier, fields, limit, sort, start);
+    return super.productMembers(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productMembersMembers(String identifier, @Valid List<String> fields,
-      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+      @Valid String node) {
     // TODO Auto-generated method stub
-    return super.productMembersMembers(identifier, fields, limit, sort, start);
+    return super.productMembersMembers(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productMembersMembersVers(String identifier, String versions,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.productMembersMembersVers(identifier, versions, fields, limit, sort, start);
+    return super.productMembersMembersVers(identifier, versions, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> productMembersVers(String identifier, String versions,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.productMembersVers(identifier, versions, fields, limit, sort, start);
+    return super.productMembersVers(identifier, versions, fields, limit, sort, start, node);
   }
 
   @Override
-  public ResponseEntity<Object> selectByLidvid(String identifier, @Valid List<String> fields) {
+  public ResponseEntity<Object> selectByLidvid(String identifier, @Valid List<String> fields,
+      @Valid String node) {
     // TODO Auto-generated method stub
-    return super.selectByLidvid(identifier, fields);
+    return super.selectByLidvid(identifier, fields, node);
   }
 
   @Override
   public ResponseEntity<Object> selectByLidvidAll(String identifier, @Valid List<String> fields,
-      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer limit, @Valid List<String> sort, @Min(0) @Valid Integer start,
+      @Valid String node) {
     // TODO Auto-generated method stub
-    return super.selectByLidvidAll(identifier, fields, limit, sort, start);
+    return super.selectByLidvidAll(identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> selectByLidvidLatest(String identifier,
-      @Valid List<String> fields) {
+      @Valid List<String> fields, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.selectByLidvidLatest(identifier, fields);
+    return super.selectByLidvidLatest(identifier, fields, node);
   }
 
   @Override
@@ -404,74 +417,77 @@ public class SwaggerJavaTransmuter extends SwaggerJavaDeprecatedTransmuter
   @Override
   public ResponseEntity<Object> classList(String propertyClass, @Valid List<String> fields,
       @Valid List<String> keywords, @Min(0) @Valid Integer limit, @Valid String q,
-      @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Valid List<String> sort, @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.classList(propertyClass, fields, keywords, limit, q, sort, start);
+    return super.classList(propertyClass, fields, keywords, limit, q, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> classMemberOf(String propertyClass, String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.classMemberOf(propertyClass, identifier, fields, limit, sort, start);
+    return super.classMemberOf(propertyClass, identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> classMemberOfOf(String propertyClass, String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.classMemberOfOf(propertyClass, identifier, fields, limit, sort, start);
+    return super.classMemberOfOf(propertyClass, identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> classMemberOfOfVers(String propertyClass, String identifier,
       String versions, @Valid List<String> fields, @Min(0) @Valid Integer limit,
-      @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Valid List<String> sort, @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
     return super.classMemberOfOfVers(propertyClass, identifier, versions, fields, limit, sort,
-        start);
+        start, node);
   }
 
   @Override
   public ResponseEntity<Object> classMemberOfVers(String propertyClass, String identifier,
       String versions, @Valid List<String> fields, @Min(0) @Valid Integer limit,
-      @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Valid List<String> sort, @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.classMemberOfVers(propertyClass, identifier, versions, fields, limit, sort, start);
+    return super.classMemberOfVers(propertyClass, identifier, versions, fields, limit, sort, 
+        start, node);
   }
 
   @Override
   public ResponseEntity<Object> classMembers(String propertyClass, String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.classMembers(propertyClass, identifier, fields, limit, sort, start);
+    return super.classMembers(propertyClass, identifier, fields, limit, sort, start, node);
   }
 
   @Override
   public ResponseEntity<Object> classMembersMembers(String propertyClass, String identifier,
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
-      @Min(0) @Valid Integer start) {
+      @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.classMembersMembers(propertyClass, identifier, fields, limit, sort, start);
+    return super.classMembersMembers(propertyClass, identifier, fields, limit, sort, start, 
+        node);
   }
 
   @Override
   public ResponseEntity<Object> classMembersMembersVers(String propertyClass, String identifier,
       String versions, @Valid List<String> fields, @Min(0) @Valid Integer limit,
-      @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Valid List<String> sort, @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
     return super.classMembersMembersVers(propertyClass, identifier, versions, fields, limit, sort,
-        start);
+        start, node);
   }
 
   @Override
   public ResponseEntity<Object> classMembersVers(String propertyClass, String identifier,
       String versions, @Valid List<String> fields, @Min(0) @Valid Integer limit,
-      @Valid List<String> sort, @Min(0) @Valid Integer start) {
+      @Valid List<String> sort, @Min(0) @Valid Integer start, @Valid String node) {
     // TODO Auto-generated method stub
-    return super.classMembersVers(propertyClass, identifier, versions, fields, limit, sort, start);
+    return super.classMembersVers(propertyClass, identifier, versions, fields, limit, sort, 
+        start, node);
   }
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
@@ -45,6 +45,8 @@ class URIParameters implements UserContext {
   private List<String> sort = new ArrayList<String>();
   private String version = "latest";
 
+  private String node = "";
+
   @Override
   public String getAccept() {
     return accept;
@@ -112,6 +114,11 @@ class URIParameters implements UserContext {
   @Override
   public String getVersion() {
     return version;
+  }
+
+  @Override
+  public String getNode() {
+    return node;
   }
 
   public URIParameters setAccept(String accept) {
@@ -214,6 +221,11 @@ class URIParameters implements UserContext {
       this.version = version.toString().toLowerCase();
       this.selector = version;
     }
+    return this;
+  }
+
+  public URIParameters setNode(String node) {
+    if (node != null) this.node = node;
     return this;
   }
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/ProductQueryBuilderUtil.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/ProductQueryBuilderUtil.java
@@ -66,6 +66,14 @@ public class ProductQueryBuilderUtil {
     boolQuery.mustNot(QueryBuilders.existsQuery("ops:Provenance/ops:superseded_by"));
   }
 
+  public static void addNodeFilter(BoolQueryBuilder boolQuery, String node) {
+    log.debug("addNodeFilter: " + node);
+
+    if (node == null || node.trim() == "") return;
+
+    boolQuery.must(QueryBuilders.termsQuery("ops:Harvest_Info/ops:node_name", node));
+  }
+ 
   public static void addPresetCriteria(BoolQueryBuilder boolQuery, GroupConstraint presetCriteria) {
     if (presetCriteria != null) {
       presetCriteria.all().forEach((key, list) -> {

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RequestAndResponseContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RequestAndResponseContext.java
@@ -43,6 +43,7 @@ public class RequestAndResponseContext implements RequestBuildContext, RequestCo
   final private List<String> sort;
   final private int start;
   final private int limit;
+  final private String node;
 
   final private boolean singletonResultExpected;
   final private GroupConstraint presetCriteria;
@@ -133,6 +134,7 @@ public class RequestAndResponseContext implements RequestBuildContext, RequestCo
             .given(parameters.getSelector() == ProductVersionSelector.LATEST, fields, resPreset));
     this.start = parameters.getStart();
     this.limit = parameters.getLimit();
+    this.node = parameters.getNode();
     this.singletonResultExpected = parameters.getSingletonResultExpected();
     this.sort = parameters.getSort();
     this.presetCriteria = outPreset;
@@ -173,6 +175,10 @@ public class RequestAndResponseContext implements RequestBuildContext, RequestCo
 
   public int getLimit() {
     return this.limit;
+  }
+
+  public String getNode() {
+    return this.node;
   }
 
   @Override
@@ -284,6 +290,7 @@ public class RequestAndResponseContext implements RequestBuildContext, RequestCo
         log.warn("    " + keyword);
       log.warn("   lidvid: " + this.getProductIdentifierString());
       log.warn("   limit: " + String.valueOf(this.getLimit()));
+      log.warn("   node: " + this.getNode());
       log.warn("   query string: " + String.valueOf(this.getQueryString()));
       log.warn("   selector: " + String.valueOf(this.getSelector()));
       log.warn("   sorting: " + String.valueOf(this.getSort().size()));
@@ -301,6 +308,7 @@ public class RequestAndResponseContext implements RequestBuildContext, RequestCo
     summary.setQ(this.getQueryString());
     summary.setStart(this.getStart());
     summary.setLimit(this.getLimit());
+    summary.setNode(this.getNode());
     summary.setSort(this.getSort());
     summary.setHits(this.formatters.get(this.format).setResponse(hits, summary, this.fields));
     summary.setProperties(new ArrayList<String>());
@@ -328,6 +336,7 @@ public class RequestAndResponseContext implements RequestBuildContext, RequestCo
       summary.setLimit(this.getLimit());
       summary.setSort(this.getSort());
       summary.setHits(total_hits);
+      summary.setNode(this.getNode());
 
       if (uniqueProperties != null)
         summary.setProperties(uniqueProperties);

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/SearchRequestFactory.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/SearchRequestFactory.java
@@ -101,6 +101,7 @@ public class SearchRequestFactory {
 
       ProductQueryBuilderUtil.addArchiveStatusFilter(this.base);
       ProductQueryBuilderUtil.addPresetCriteria(this.base, context.getPresetCriteria());
+      ProductQueryBuilderUtil.addNodeFilter(this.base, context.getNode());
     }
 
     return new SearchRequest().indices(index)

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/SimpleRequestBuildContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/SimpleRequestBuildContext.java
@@ -11,23 +11,34 @@ class SimpleRequestBuildContext implements RequestBuildContext {
   final private boolean justLatest;
   final private List<String> fields;
   final private GroupConstraint preset;
+  final private String node;
 
   SimpleRequestBuildContext(boolean justLatest) {
     this.fields = new ArrayList<String>();
     this.justLatest = justLatest;
     this.preset = GroupConstraintImpl.empty();
+    this.node = "";
   }
 
   SimpleRequestBuildContext(boolean justLatest, List<String> fields) {
     this.fields = fields;
     this.justLatest = justLatest;
     this.preset = GroupConstraintImpl.empty();
+    this.node = "";
   }
 
   SimpleRequestBuildContext(boolean justLatest, List<String> fields, GroupConstraint preset) {
     this.fields = fields;
     this.justLatest = justLatest;
     this.preset = preset;
+    this.node = "";
+  }
+
+  SimpleRequestBuildContext(boolean justLatest, List<String> fields, GroupConstraint preset, String node) {
+    this.fields = fields;
+    this.justLatest = justLatest;
+    this.preset = preset;
+    this.node = node;
   }
 
   @Override
@@ -43,5 +54,10 @@ class SimpleRequestBuildContext implements RequestBuildContext {
   @Override
   public GroupConstraint getPresetCriteria() {
     return this.preset;
+  }
+
+  @Override
+  public String getNode() {
+    return this.node;
   }
 }


### PR DESCRIPTION
## 🗒️ Summary
Enable registry multi-tenancy : co-located documents from various nodes within a single Opensearch domain. Provide support for a 'node=<id>' query parameter to all API endpoints which filters documents having 'ops:Harvest_Info/ops:node_name' equal to that value.

Also included is the modified CloudFront function which now passes an HTTP header 'x-request-version' that identifies the API version. This should be consumed by the EC2 Load Balancer rules to direct to the appropriate service (currently ECS/Fargate) endpoint/listener.

THIS PR SHOULD NOT BE MERGED AT THIS POINT IN TIME but is provided to ensure that all bases wrt the service code have been considered.

refs https://github.com/NASA-PDS/registry/issues/155
refs https://github.com/NASA-PDS/registry-api/issues/304