### PR TITLE
Change provenance to filter relevant LIDVIDs on "archive_status in [archived, certified]"

### DIFF
--- a/support/provenance/provenance.py
+++ b/support/provenance/provenance.py
@@ -115,10 +115,10 @@ def get_historic(provenance: {str: str}, reset: bool) -> {str: str}:  # TODO: po
     log.info('starting search for history')
 
     log.info('   reduce lidvids to unique lids')
-    sorted_lids = sorted({lidvid.split('::')[0] for lidvid in provenance})  # todo: what does sorting accomplish here?  Seems to be nothing.
+    lids = {lidvid.split('::')[0] for lidvid in provenance}
 
     log.info('   aggregate lidvids into lid buckets')
-    lidvids_by_lid = {lid: [] for lid in sorted_lids}
+    lidvids_by_lid = {lid: [] for lid in lids}
     for lidvid in provenance:
         lid = lidvid.split('::')[0]
         lidvids_by_lid[lid].append(lidvid)

--- a/support/provenance/provenance.py
+++ b/support/provenance/provenance.py
@@ -93,7 +93,6 @@ def run(
         username: str,
         password: str,
         verify_host_certs: bool = False,
-        reset: bool = False,
         log_filepath: Union[str, None] = None,
         log_level: int = logging.INFO):
     configure_logging(filepath=log_filepath, log_level=log_level)
@@ -103,7 +102,7 @@ def run(
     host = HOST(cluster_nodes, password, base_url, username, verify_host_certs)
 
     provenance = trawl_registry(host)
-    updates = get_historic(provenance, reset)
+    updates = get_historic(provenance)
 
     if updates:
         update_docs(host, updates)
@@ -111,7 +110,7 @@ def run(
     log.info('completed CLI processing')
 
 
-def get_historic(provenance: {str: str}, reset: bool) -> {str: str}:  # TODO: populate comment and rename for clarity
+def get_historic(provenance: {str: str}) -> {str: str}:  # TODO: populate comment and rename for clarity
     log.info('starting search for history')
 
     log.info('   reduce lidvids to unique lids')
@@ -132,8 +131,7 @@ def get_historic(provenance: {str: str}, reset: bool) -> {str: str}:  # TODO: po
         lidvids.sort(key=_vid_as_tuple_of_int, reverse=True)
 
         for index, lidvid in enumerate(lidvids[1:]):
-            if reset or not provenance[lidvid]:  # todo: this seems to result in an error if (for example) v1, v3 exist, and v2 is added later
-                history[lidvid] = lidvids[index]
+            history[lidvid] = lidvids[index]
 
     log.info(
         f'found {len(history)} products needing update of a {updated_products_count} full history of {len(provenance)} total products')
@@ -245,8 +243,6 @@ if __name__ == '__main__':
                     help='Python logging level as an int or string like INFO for logging.INFO [%(default)s]')
     ap.add_argument('-p', '--password', default=None, required=False,
                     help='password to login to opensearch leaving it blank if opensearch does not require login')
-    ap.add_argument('-r', '--reset', action='store_true', default=False,
-                    help='ignore existing provenance building it from scratch')
     ap.add_argument('-u', '--username', default=None, required=False,
                     help='username to login to opensearch leaving it blank if opensearch does not require login')
     ap.add_argument('-v', '--verify', action='store_true', default=False,
@@ -259,6 +255,5 @@ if __name__ == '__main__':
         username=args.username,
         password=args.password,
         verify_host_certs=args.verify,
-        reset=args.reset,
         log_level=args.log_level,
         log_filepath=args.log_file)

--- a/support/provenance/provenance.py
+++ b/support/provenance/provenance.py
@@ -155,8 +155,8 @@ def get_extant_lidvids(host: HOST) -> Iterable[str]:
     clusters = [node + ":registry" for node in host.nodes]
     path = ','.join(['registry'] + clusters) + '/_search?scroll=10m'
     extant_lidvids = []
-    query = {'query': {'bool': {'must_not': [
-        {'term': {'ops:Tracking_Meta/ops:archive_status': 'staged'}}]}},
+    query = {'query': {'bool': {'must': [
+        {'terms': {'ops:Tracking_Meta/ops:archive_status': ['archived', 'certified']}}]}},
         '_source': {'includes': ['lidvid']},
         'size': 10000}
 

--- a/support/provenance/provenance.py
+++ b/support/provenance/provenance.py
@@ -128,7 +128,7 @@ def get_historic(provenance: {str: str}, reset: bool) -> {str: str}:  # TODO: po
     history = {}
     lidvid_aggregates_with_multiple_versions = filter(lambda l: 1 < len(l), lidvids_by_lid.values())
     for lidvids in lidvid_aggregates_with_multiple_versions:
-        updated_products_count += len(lidvids)  # todo: technically this isn't true - should be len(lidvids) - 1 as earliest version requires no update
+        updated_products_count += len(lidvids) - 1
         lidvids.sort(key=_vid_as_tuple_of_int, reverse=True)
 
         for index, lidvid in enumerate(lidvids[1:]):

--- a/support/provenance/provenance_driver.py
+++ b/support/provenance/provenance_driver.py
@@ -72,7 +72,7 @@ remotesStr = os.environ.get("PROV_REMOTES")
 if remotesStr is not None and remotesStr.strip() != '':
     remotesLists = json.loads(remotesStr)
 
-command = f'provenance.py -b {opensearch_endpoint} -l provenance.log -L DEBUG --reset '
+command = f'provenance.py -b {opensearch_endpoint} -l provenance.log -L DEBUG'
 if username is not None:
     command += f' -u {username} -p {passwd}'
 


### PR DESCRIPTION
### IGNORE THIS PR UNTIL #311 IS MERGED
There's a minor conflict it seemed simpler not to bother dealing with.  This PR is actually only ce7f755341f38a3116d394c3fae6e87b3ea850bd, which is a trivial diff.

## 🗒️ Summary
Previously, filtering occurred on "archive_status != staged", which was causing API issues where archive_status was erroneously nulled.

## ⚙️ Test Data and/or Report
Manually tested only

## ♻️ Related Issues
Fixes #305 