### PR TITLE
Upgrading nexus-staging-maven-plugin 1.6.8 → 1.6.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@ Go through this file line-by-line and replace the template values with your own.
         <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
                 <serverId>ossrh</serverId>


### PR DESCRIPTION
## 🗒️ Summary

Merge this to upgrade the `nexus-staging-maven-plugin` version from 1.6.3 → 1.6.13.

## ⚙️ Test Data and/or Report

Left as an exercise to the reader.


## ♻️ Related Issues

- #314 
