### PR TITLE
Update github actions for deprecation

### DIFF
--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -85,7 +85,7 @@ jobs:
                 name: 🫙 Jar and Tag Determination
                 id: jartag
                 run: |
-                    echo "jar_file=$(ls ./service/target/*.jar)" >> $GITHUB_OUTPUT
+                    echo "jar_file=$(find ./service/target/ -maxdepth 1 -regextype posix-extended -regex '.*/registry-api-service-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.jar')" >> $GITHUB_OUTPUT
                     echo "image_tag=$(echo ${{github.ref}} | awk -F/ '{print $NF}')" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification

--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -85,8 +85,8 @@ jobs:
                 name: 🫙 Jar and Tag Determination
                 id: jartag
                 run: |
-                    echo "::set-output name=jar_file::$(ls ./service/target/*.jar)"
-                    echo "::set-output name=image_tag::$(echo ${{github.ref}} | awk -F/ '{print $NF}')"
+                    echo "jar_file=$(ls ./service/target/*.jar)" >> $GITHUB_OUTPUT
+                    echo "image_tag=$(echo ${{github.ref}} | awk -F/ '{print $NF}')" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification
                 uses: docker/login-action@v2

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -80,7 +80,7 @@ jobs:
             -
                 name: 🫙 Jar File Determination
                 id: jarrer
-                run: echo "jar_file=$(ls ./service/target/*.jar)" >> $GITHUB_OUTPUT
+                run: echo "jar_file=$(find ./service/target/ -maxdepth 1 -regextype posix-extended -regex '.*/registry-api-service-[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?\.jar')" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification
                 uses: docker/login-action@v2

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -80,7 +80,7 @@ jobs:
             -
                 name: 🫙 Jar File Determination
                 id: jarrer
-                run: echo "::set-output name=jar_file::$(ls ./service/target/*.jar)"
+                run: echo "jar_file=$(ls ./service/target/*.jar)" >> $GITHUB_OUTPUT
             -
                 name: 💳 Docker Hub Identification
                 uses: docker/login-action@v2


### PR DESCRIPTION
## 🗒️ Summary
Addresses ::set-output deprecation
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## ⚙️ Test Data and/or Report
Not tested - will require visual review, and testing after merge

## ♻️ Related Issues
https://github.com/NASA-PDS/devops/issues/43