### PR TITLE
fix erroneous validation failure of VID major-version zero

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsVid.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/PdsVid.java
@@ -5,8 +5,8 @@ public class PdsVid implements Comparable<PdsVid> {
   private final int minorVersion;
 
   public PdsVid(int majorVersion, int minorVersion) {
-    if (majorVersion < 1) {
-      String errMsg = String.format("majorVersion must be 1 or higher (got '%d'))", majorVersion);
+    if (majorVersion < 0) {
+      String errMsg = String.format("majorVersion must be 0 or higher (got '%d'))", majorVersion);
       throw new IllegalArgumentException(errMsg);
     }
 

--- a/service/src/test/java/gov/nasa/pds/api/registry/model/PdsVidTest.java
+++ b/service/src/test/java/gov/nasa/pds/api/registry/model/PdsVidTest.java
@@ -14,10 +14,6 @@ public class PdsVidTest {
   @Test
   public void testInvalidInstantiations() {
     Assert.assertThrows(IllegalArgumentException.class, () -> {
-      PdsVid.fromString("0.1");
-    });
-
-    Assert.assertThrows(IllegalArgumentException.class, () -> {
       PdsVid.fromString("1.-1");
     });
 


### PR DESCRIPTION
## 🗒️ Summary
Major-version zero is valid, per PDS Standards Reference

## ⚙️ Test Data and/or Report
see branch tests

## ♻️ Related Issues
fixes #334 


