### PR TITLE
Fix bug with returning members of a bundle

### DIFF
--- a/service/docker/Dockerfile.local
+++ b/service/docker/Dockerfile.local
@@ -10,7 +10,7 @@ FROM ubuntu:20.04
      apt-get install -y curl \
                         libtcnative-1 \
                         maven \
-                        openjdk-11-jdk-headless \
+                        openjdk-17-jdk-headless \
                         tar
 
  # Make room for the app

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
@@ -137,7 +137,7 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic {
 
     ids.addAll(lidvids.convert(fieldMap.get("ref_lidvid_collection")));
     ids.addAll(lidvids.convert(fieldMap.get("ref_lidvid_collection_secondary")));
-
+    lidvids.addAll (ids);
     // !!! NOTE !!!
     // Harvest converts LIDVID references to LID references and stores them in
     // "ref_lid_collection" and "ref_lid_collection_secondary" fields.


### PR DESCRIPTION
## 🗒️ Summary
Added lidvids to the return list

## ⚙️ Test Data and/or Report
```
$ curl -X GET 'http://localhost:8080/products/urn:nasa:pds:mars2020.spice::3.0/members'
{"summary":{"q":"","hits":2,"took":60,"start":0,"limit":100,"sort":[],...
```
with the important bit being 2 hits

## ♻️ Related Issues
Closes #341 
Closes #355 