### PR TITLE
Issue 361: ignore data conversion errors

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/model/Pds4ProductBusinessObject.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/Pds4ProductBusinessObject.java
@@ -98,7 +98,7 @@ public class Pds4ProductBusinessObject extends ProductBusinessLogicImpl {
         if (kvp.containsKey("lidvid")) {
           lidvid = kvp.get("lidvid").toString();
         }
-        log.error ("CRITICAL: could not convert opensearch document to Pds4Product for lidvid: " + lidvid, t);
+        log.error ("DATA ERROR: could not convert opensearch document to Pds4Product for lidvid: " + lidvid, t);
       }
     }
 
@@ -127,7 +127,7 @@ public class Pds4ProductBusinessObject extends ProductBusinessLogicImpl {
         Pds4Product prod = Pds4ProductFactory.createProduct(id, fieldMap, this.isJSON);
         list.add(prod);
       } catch (Throwable t) {
-        log.error ("CRITICAL: could not convert opensearch document to Pds4Product for lidvid: " + hit.getId(), t);
+        log.error ("DATA ERROR: could not convert opensearch document to Pds4Product for lidvid: " + hit.getId(), t);
       }
     }
     products.setData(list);

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/Pds4ProductBusinessObject.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/Pds4ProductBusinessObject.java
@@ -98,7 +98,7 @@ public class Pds4ProductBusinessObject extends ProductBusinessLogicImpl {
         if (kvp.containsKey("lidvid")) {
           lidvid = kvp.get("lidvid").toString();
         }
-        log.error ("CRITICAL: could not convert opensearch document to Pds4Product for lidvid: " + lidvid);
+        log.error ("CRITICAL: could not convert opensearch document to Pds4Product for lidvid: " + lidvid, t);
       }
     }
 
@@ -127,7 +127,7 @@ public class Pds4ProductBusinessObject extends ProductBusinessLogicImpl {
         Pds4Product prod = Pds4ProductFactory.createProduct(id, fieldMap, this.isJSON);
         list.add(prod);
       } catch (Throwable t) {
-        log.error ("CRITICAL: could not convert opensearch document to Pds4Product for lidvid: " + hit.getId());
+        log.error ("CRITICAL: could not convert opensearch document to Pds4Product for lidvid: " + hit.getId(), t);
       }
     }
     products.setData(list);

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/PdsProductBusinessObject.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/PdsProductBusinessObject.java
@@ -79,7 +79,7 @@ public class PdsProductBusinessObject extends ProductBusinessLogicImpl {
         if (kvp.containsKey("lidvid")) {
           lidvid = kvp.get("lidvid").toString();
         }
-        log.error ("CRITICAL: could not convert opensearch document to EntityProduct for lidvid: " + lidvid);
+        log.error ("CRITICAL: could not convert opensearch document to EntityProduct for lidvid: " + lidvid, t);
       }
     }
     count = products.getData().size();

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/PdsProductBusinessObject.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/PdsProductBusinessObject.java
@@ -79,7 +79,7 @@ public class PdsProductBusinessObject extends ProductBusinessLogicImpl {
         if (kvp.containsKey("lidvid")) {
           lidvid = kvp.get("lidvid").toString();
         }
-        log.error ("CRITICAL: could not convert opensearch document to EntityProduct for lidvid: " + lidvid, t);
+        log.error ("DATA ERROR: could not convert opensearch document to EntityProduct for lidvid: " + lidvid, t);
       }
     }
     count = products.getData().size();
@@ -109,7 +109,7 @@ public class PdsProductBusinessObject extends ProductBusinessLogicImpl {
             .setProperties((Map<String, List<String>>) (Map<String, ?>) ProductBusinessObject
                 .getFilteredProperties(kvp, null, null));
         } catch (Throwable t) {
-          log.error("CRITICAL: could not convert opensearch document to EntityProduct for lidvid: " + hit.getId(), t);
+          log.error("DATA ERROR: could not convert opensearch document to EntityProduct for lidvid: " + hit.getId(), t);
         }
     }
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/PdsProductBusinessObject.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/PdsProductBusinessObject.java
@@ -7,6 +7,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.nasa.pds.api.registry.search.HitIterator;
 import gov.nasa.pds.model.PdsProduct;
@@ -15,6 +17,7 @@ import gov.nasa.pds.model.Summary;
 
 
 public class PdsProductBusinessObject extends ProductBusinessLogicImpl {
+  private static final Logger log = LoggerFactory.getLogger(ProductBusinessObject.class);
   private ObjectMapper objectMapper;
   private PdsProduct product = null;
   private PdsProducts products = null;
@@ -62,14 +65,22 @@ public class PdsProductBusinessObject extends ProductBusinessLogicImpl {
     Set<String> uniqueProperties = new TreeSet<String>();
 
     for (Map<String, Object> kvp : hits) {
-      uniqueProperties
-          .addAll(ProductBusinessObject.getFilteredProperties(kvp, fields, null).keySet());
+      try {
+        uniqueProperties
+            .addAll(ProductBusinessObject.getFilteredProperties(kvp, fields, null).keySet());
 
-      products.addDataItem(SearchUtil.entityProductToAPIProduct(
-          objectMapper.convertValue(kvp, EntityProduct.class), this.baseURL));
-      products.getData().get(products.getData().size() - 1)
-          .setProperties((Map<String, List<String>>) (Map<String, ?>) ProductBusinessObject
-              .getFilteredProperties(kvp, null, null));
+        products.addDataItem(SearchUtil.entityProductToAPIProduct(
+            objectMapper.convertValue(kvp, EntityProduct.class), this.baseURL));
+        products.getData().get(products.getData().size() - 1)
+            .setProperties((Map<String, List<String>>) (Map<String, ?>) ProductBusinessObject
+                .getFilteredProperties(kvp, null, null));
+      } catch (Throwable t) {
+        String lidvid = "unknown";
+        if (kvp.containsKey("lidvid")) {
+          lidvid = kvp.get("lidvid").toString();
+        }
+        log.error ("CRITICAL: could not convert opensearch document to EntityProduct for lidvid: " + lidvid);
+      }
     }
     count = products.getData().size();
 
@@ -87,15 +98,19 @@ public class PdsProductBusinessObject extends ProductBusinessLogicImpl {
     Set<String> uniqueProperties = new TreeSet<String>();
 
     for (SearchHit hit : hits) {
-      kvp = hit.getSourceAsMap();
-      uniqueProperties
-          .addAll(ProductBusinessObject.getFilteredProperties(kvp, fields, null).keySet());
+      try {
+        kvp = hit.getSourceAsMap();
+        uniqueProperties
+            .addAll(ProductBusinessObject.getFilteredProperties(kvp, fields, null).keySet());
 
-      products.addDataItem(SearchUtil.entityProductToAPIProduct(
-          objectMapper.convertValue(kvp, EntityProduct.class), this.baseURL));
-      products.getData().get(products.getData().size() - 1)
-          .setProperties((Map<String, List<String>>) (Map<String, ?>) ProductBusinessObject
-              .getFilteredProperties(kvp, null, null));
+        products.addDataItem(SearchUtil.entityProductToAPIProduct(
+            objectMapper.convertValue(kvp, EntityProduct.class), this.baseURL));
+        products.getData().get(products.getData().size() - 1)
+            .setProperties((Map<String, List<String>>) (Map<String, ?>) ProductBusinessObject
+                .getFilteredProperties(kvp, null, null));
+        } catch (Throwable t) {
+          log.error("CRITICAL: could not convert opensearch document to EntityProduct for lidvid: " + hit.getId(), t);
+        }
     }
 
     summary.setProperties(new ArrayList<String>(uniqueProperties));

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -36,7 +36,7 @@ openSearch.username=admin
 openSearch.password=admin
 openSearch.ssl=true
 # use only for development purpose, left it to true otherwise
-openSearch.sslCertificateCNVerification=true
+openSearch.sslCertificateCNVerification=false
 
 # Only show products with following archive statuses
 filter.archiveStatus=archived,certified

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -36,7 +36,7 @@ openSearch.username=admin
 openSearch.password=admin
 openSearch.ssl=true
 # use only for development purpose, left it to true otherwise
-openSearch.sslCertificateCNVerification=false
+openSearch.sslCertificateCNVerification=true
 
 # Only show products with following archive statuses
 filter.archiveStatus=archived,certified


### PR DESCRIPTION
## 🗒️ Summary
Ignore any errors while converting from the opensearch document to PDS defined data types/structures. This allows processing to continue with just errors in the log.

## ⚙️ Test Data and/or Report
None - do not have access to a db with bad data

## ♻️ Related Issues
Closes #361 