### PR TITLE
Replace default string representation of Iterable fields with pipe-delimited format for some Accepts types

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/model/WyriwygBusinessObject.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/WyriwygBusinessObject.java
@@ -111,7 +111,7 @@ public class WyriwygBusinessObject extends ProductBusinessLogicImpl {
         WyriwygProductKeyValuePair kvp = new WyriwygProductKeyValuePair();
         try {
           kvp.setKey(SearchUtil.openPropertyToJsonProperty(pair.getKey()));
-          kvp.setValue(String.valueOf(pair.getValue()));
+          kvp.setValue(getStringValueOf(pair.getValue()));
           product.addKeyValuePairsItem(kvp);
         } catch (UnsupportedSearchProperty e) {
           log.warn("openSearch property " + pair.getKey() + " is not supported, ignored");
@@ -124,5 +124,22 @@ public class WyriwygBusinessObject extends ProductBusinessLogicImpl {
     products.setSummary(summary);
     this.products = products;
     return (int) (hits.getTotalHits().value);
+  }
+
+  private String getStringValueOf(Object o) {
+    String valueOf;
+    if (o instanceof Iterable) {
+      List<String> stringRepresentations = new ArrayList<>();
+      for (Object el : (Iterable<Object>) o ) {
+        stringRepresentations.add(String.valueOf(el));
+      }
+
+      String delimiter = "|";
+      valueOf = String.join(delimiter, stringRepresentations);
+    } else {
+      valueOf = String.valueOf(o);
+    }
+
+    return valueOf;
   }
 }


### PR DESCRIPTION
affects application/csv, application/kvp+json, and text/csv return types fixes #375

## 🗒️ Summary
Previously, array-like properties would be formatted `[a, collection, of, elements]`
Now, they are formatted `a|collection|of|elements`, per @tloubrieu-jpl request in #375 

## ⚙️ Test Data and/or Report
Manually tested

## ♻️ Related Issues
fixes #375 