### PR TITLE
Optional ccs

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/search/OpenSearchConfig.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/OpenSearchConfig.java
@@ -38,15 +38,22 @@ public class OpenSearchConfig {
 
   @Value("${openSearch.timeOutSeconds:60}")
   private int timeOutSeconds;
-
+  
   public int getTimeOutSeconds() {
     return timeOutSeconds;
   }
-
+  
   public void setTimeOutSeconds(int timeOutSeconds) {
     this.timeOutSeconds = timeOutSeconds;
   }
-
+  
+  @Value("${openSearch.CCSEnabled:true}")
+  private boolean CCSEnabled;
+  
+  public boolean getCCSEnabled() {
+    return CCSEnabled;
+  }
+  
   @Value("${openSearch.username:}")
   private String username;
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/OpenSearchRegistryConnectionImpl.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/OpenSearchRegistryConnectionImpl.java
@@ -38,7 +38,7 @@ public class OpenSearchRegistryConnectionImpl implements ConnectionContext {
   public static String CLUSTER_REMOTE_KEY = "cluster.remote";
 
   private static final Logger log = LoggerFactory.getLogger(OpenSearchRegistryConnectionImpl.class);
-
+ 
   private RestHighLevelClient restHighLevelClient;
   private String registryIndex;
   private String registryRefIndex;
@@ -106,8 +106,15 @@ public class OpenSearchRegistryConnectionImpl implements ConnectionContext {
 
     this.restHighLevelClient = new RestHighLevelClient(clientBuilder);
 
-    this.crossClusterNodes = checkCCSConfig();
-    this.registryIndex = createCCSIndexString(connectionBuilder.getRegistryIndex());
+    String registryIndex = connectionBuilder.getRegistryIndex();
+    if (connectionBuilder.getCCSEnabled()) {
+      this.crossClusterNodes = checkCCSConfig();
+      this.registryIndex = createCCSIndexString(registryIndex);
+    }
+    else {
+      this.registryIndex = registryIndex;
+    }
+    
     this.registryRefIndex = createCCSIndexString(connectionBuilder.getRegistryRefIndex());
     this.timeOutSeconds = connectionBuilder.getTimeOutSeconds();
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/OpenSearchRegistryConnectionImplBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/OpenSearchRegistryConnectionImplBuilder.java
@@ -55,6 +55,11 @@ class OpenSearchRegistryConnectionImplBuilder {
     return timeOutSeconds;
   }
 
+  
+  public boolean getCCSEnabled() {
+    return CCSEnabled;
+  }
+  
   public boolean isSsl() {
     return ssl;
   }
@@ -66,6 +71,7 @@ class OpenSearchRegistryConnectionImplBuilder {
   private final String registryIndex;
   private final String registryRefIndex;
   private final int timeOutSeconds;
+  private final boolean CCSEnabled;
   private final boolean ssl;
   private final boolean sslCertificateCNVerification;
 
@@ -78,6 +84,7 @@ class OpenSearchRegistryConnectionImplBuilder {
     this.registryIndex = "registry";
     this.registryRefIndex = "registry-refs";
     this.timeOutSeconds = 5;
+    this.CCSEnabled = true;
     this.username = null;
     this.password = null;
     this.ssl = false;
@@ -91,6 +98,7 @@ class OpenSearchRegistryConnectionImplBuilder {
     this.registryIndex = openSearchConfig.getRegistryIndex();
     this.registryRefIndex = openSearchConfig.getRegistryRefIndex();
     this.timeOutSeconds = openSearchConfig.getTimeOutSeconds();
+    this.CCSEnabled = openSearchConfig.getCCSEnabled();
     this.ssl = openSearchConfig.isSsl();
     this.sslCertificateCNVerification = openSearchConfig.doesSslCertificateVCNerification();
     this.username = openSearchConfig.getUsername();

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -32,6 +32,7 @@ openSearch.host=localhost:9200
 openSearch.registryIndex=registry
 openSearch.registryRefIndex=registry-refs
 openSearch.timeOutSeconds=60
+openSearch.CCSEnabled=true
 openSearch.username=admin
 openSearch.password=admin
 openSearch.ssl=true


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Adds a configuration to ignore the CCS OpenSearch configuration and only connect to the main registry index.
This is useful when someone want to test on a production opensearch without being authorized to access all the CCS connected openSearch.

Default is CCSEnabled=true so that the current behavior is not altered.

## ⚙️ Test Data and/or Report

One can test with applications.properties section as follow:

"""
# note the port is mandatory even when it is default :80 or :443
openSearch.host=__the_production_opensearch__
openSearch.registryIndex=registry
openSearch.registryRefIndex=registry-refs
openSearch.timeOutSeconds=60
openSearch.CCSEnabled=false
openSearch.username=__your_opensearch_user___
openSearch.password=__your_password__
openSearch.ssl=true
# use only for development purpose, left it to true otherwise
openSearch.sslCertificateCNVerification=true
"""

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


