### PR TITLE
Replace remaining string PDS product ids with PdsProductIdentifier objects

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/UserContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/UserContext.java
@@ -3,6 +3,7 @@ package gov.nasa.pds.api.registry;
 import java.util.List;
 
 import gov.nasa.pds.api.registry.model.ProductVersionSelector;
+import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 
 public interface UserContext extends LidvidsContext {
   public String getAccept();
@@ -11,7 +12,7 @@ public interface UserContext extends LidvidsContext {
 
   public String getGroup();
 
-  public String getIdentifier();
+  public PdsProductIdentifier getIdentifier();
 
   public List<String> getKeywords();
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaClassesTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaClassesTransmuter.java
@@ -1,6 +1,8 @@
 package gov.nasa.pds.api.registry.controller;
 
 import java.util.List;
+
+import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import org.springframework.http.HttpStatus;
@@ -37,7 +39,7 @@ abstract class SwaggerJavaClassesTransmuter extends SwaggerJavaBaseTransmuter
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
       @Valid List<String> searchAfter) {
     return this.processs(new Member(false, false),
-        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(identifier)
+        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(PdsProductIdentifier.fromString(identifier))
             .setFields(fields).setLimit(limit).setSort(sort).setSearchAfter(sort, searchAfter)
             .setVerifyClassAndId(true).build());
   }
@@ -47,7 +49,7 @@ abstract class SwaggerJavaClassesTransmuter extends SwaggerJavaBaseTransmuter
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
       @Valid List<String> searchAfter) {
     return this.processs(new Member(false, true),
-        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(identifier)
+        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(PdsProductIdentifier.fromString(identifier))
             .setFields(fields).setLimit(limit).setSort(sort).setSearchAfter(sort, searchAfter)
             .setVerifyClassAndId(true).build());
   }
@@ -57,7 +59,7 @@ abstract class SwaggerJavaClassesTransmuter extends SwaggerJavaBaseTransmuter
       String versions, @Valid List<String> fields, @Min(0) @Valid Integer limit,
       @Valid List<String> sort, @Valid List<String> searchAfter) {
     return this.processs(new Member(false, true),
-        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(identifier)
+        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(PdsProductIdentifier.fromString(identifier))
             .setFields(fields).setLimit(limit).setSort(sort).setSearchAfter(sort, searchAfter)
             .setVerifyClassAndId(true).setVersion(versions).build());
   }
@@ -67,7 +69,7 @@ abstract class SwaggerJavaClassesTransmuter extends SwaggerJavaBaseTransmuter
       String versions, @Valid List<String> fields, @Min(0) @Valid Integer limit,
       @Valid List<String> sort, @Valid List<String> searchAfter) {
     return this.processs(new Member(false, false),
-        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(identifier)
+        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(PdsProductIdentifier.fromString(identifier))
             .setFields(fields).setLimit(limit).setSort(sort).setSearchAfter(sort, searchAfter)
             .setVerifyClassAndId(true).setVersion(versions).build());
   }
@@ -77,7 +79,7 @@ abstract class SwaggerJavaClassesTransmuter extends SwaggerJavaBaseTransmuter
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
       @Valid List<String> searchAfter) {
     return this.processs(new Member(true, false),
-        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(identifier)
+        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(PdsProductIdentifier.fromString(identifier))
             .setFields(fields).setLimit(limit).setSort(sort).setSearchAfter(sort, searchAfter)
             .setVerifyClassAndId(true).build());
   }
@@ -87,7 +89,7 @@ abstract class SwaggerJavaClassesTransmuter extends SwaggerJavaBaseTransmuter
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
       @Valid List<String> searchAfter) {
     return this.processs(new Member(true, true),
-        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(identifier)
+        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(PdsProductIdentifier.fromString(identifier))
             .setFields(fields).setLimit(limit).setSort(sort).setSearchAfter(sort, searchAfter)
             .setVerifyClassAndId(true).build());
   }
@@ -97,7 +99,7 @@ abstract class SwaggerJavaClassesTransmuter extends SwaggerJavaBaseTransmuter
       String versions, @Valid List<String> fields, @Min(0) @Valid Integer limit,
       @Valid List<String> sort, @Valid List<String> searchAfter) {
     return this.processs(new Member(true, true),
-        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(identifier)
+        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(PdsProductIdentifier.fromString(identifier))
             .setFields(fields).setLimit(limit).setSort(sort).setSearchAfter(sort, searchAfter)
             .setVerifyClassAndId(true).setVersion(versions).build());
   }
@@ -107,7 +109,7 @@ abstract class SwaggerJavaClassesTransmuter extends SwaggerJavaBaseTransmuter
       String versions, @Valid List<String> fields, @Min(0) @Valid Integer limit,
       @Valid List<String> sort, @Valid List<String> searchAfter) {
     return this.processs(new Member(true, false),
-        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(identifier)
+        this.uriParametersBuilder.setGroup(propertyClass).setIdentifier(PdsProductIdentifier.fromString(identifier))
             .setFields(fields).setLimit(limit).setSort(sort).setSearchAfter(sort, searchAfter)
             .setVerifyClassAndId(true).setVersion(versions).build());
   }

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaDeprecatedTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaDeprecatedTransmuter.java
@@ -1,6 +1,8 @@
 package gov.nasa.pds.api.registry.controller;
 
 import java.util.List;
+
+import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +23,7 @@ abstract class SwaggerJavaDeprecatedTransmuter extends SwaggerJavaProductsTransm
   @Override
   public ResponseEntity<Object> bundlesLidvid(String identifier, @Valid List<String> fields) {
     return this.processs(new Standard(), this.uriParametersBuilder.setGroup("bundles")
-        .setIdentifier(identifier).setFields(fields).setVerifyClassAndId(true).build());
+        .setIdentifier(PdsProductIdentifier.fromString(identifier)).setFields(fields).setVerifyClassAndId(true).build());
   }
 
   @Override
@@ -29,7 +31,7 @@ abstract class SwaggerJavaDeprecatedTransmuter extends SwaggerJavaProductsTransm
       @Min(0) @Valid Integer limit, @Valid List<String> sort, @Valid List<String> searchAfter) {
 //    TODO: Investigate why start/searchAfter is just disregarded for this endpoint
     return this.processs(new Standard(),
-        this.uriParametersBuilder.setGroup("bundles").setIdentifier(identifier).setFields(fields)
+        this.uriParametersBuilder.setGroup("bundles").setIdentifier(PdsProductIdentifier.fromString(identifier)).setFields(fields)
             .setVerifyClassAndId(true).setVersion(ProductVersionSelector.ALL).build());
   }
 
@@ -57,7 +59,7 @@ abstract class SwaggerJavaDeprecatedTransmuter extends SwaggerJavaProductsTransm
   @Override
   public ResponseEntity<Object> bundlesLidvidLatest(String identifier, @Valid List<String> fields) {
     return this.processs(new Standard(),
-        this.uriParametersBuilder.setGroup("bundles").setIdentifier(identifier).setFields(fields)
+        this.uriParametersBuilder.setGroup("bundles").setIdentifier(PdsProductIdentifier.fromString(identifier)).setFields(fields)
             .setVerifyClassAndId(true).setVersion(ProductVersionSelector.LATEST).build());
   }
 
@@ -77,7 +79,7 @@ abstract class SwaggerJavaDeprecatedTransmuter extends SwaggerJavaProductsTransm
   @Override
   public ResponseEntity<Object> collectionsLidvid(String identifier, @Valid List<String> fields) {
     return this.processs(new Standard(), this.uriParametersBuilder.setGroup("collections")
-        .setIdentifier(identifier).setFields(fields).setVerifyClassAndId(true).build());
+        .setIdentifier(PdsProductIdentifier.fromString(identifier)).setFields(fields).setVerifyClassAndId(true).build());
   }
 
   @Override
@@ -85,7 +87,7 @@ abstract class SwaggerJavaDeprecatedTransmuter extends SwaggerJavaProductsTransm
       @Min(0) @Valid Integer limit, @Valid List<String> sort, @Valid List<String> searchAfter) {
 //    TODO: Investigate why start/searchAfter is disregarded in this case
     return this.processs(new Standard(),
-        this.uriParametersBuilder.setGroup("collections").setIdentifier(identifier)
+        this.uriParametersBuilder.setGroup("collections").setIdentifier(PdsProductIdentifier.fromString(identifier))
             .setFields(fields).setVerifyClassAndId(true).setVersion(ProductVersionSelector.ALL)
             .build());
   }
@@ -101,7 +103,7 @@ abstract class SwaggerJavaDeprecatedTransmuter extends SwaggerJavaProductsTransm
   public ResponseEntity<Object> collectionsLidvidLatest(String identifier,
       @Valid List<String> fields) {
     return this.processs(new Standard(),
-        this.uriParametersBuilder.setGroup("collections").setIdentifier(identifier)
+        this.uriParametersBuilder.setGroup("collections").setIdentifier(PdsProductIdentifier.fromString(identifier))
             .setFields(fields).setVerifyClassAndId(true).setVersion(ProductVersionSelector.LATEST)
             .build());
   }

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaProductsTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaProductsTransmuter.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import gov.nasa.pds.api.base.PropertiesApi;
+import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 import gov.nasa.pds.model.ProductPropertiesList200ResponseInner;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -43,7 +44,7 @@ abstract class SwaggerJavaProductsTransmuter extends SwaggerJavaClassesTransmute
   public ResponseEntity<Object> productMemberOf(String identifier, @Valid List<String> fields,
       @Min(0) @Valid Integer limit, @Valid List<String> sort, @Valid List<String> searchAfter) {
     return this.processs(new Member(false, false),
-        this.uriParametersBuilder.setIdentifier(identifier).setFields(fields).setLimit(limit)
+        this.uriParametersBuilder.setIdentifier(PdsProductIdentifier.fromString(identifier)).setFields(fields).setLimit(limit)
             .setSort(sort).setSearchAfter(sort, searchAfter).build());
   }
 
@@ -51,7 +52,7 @@ abstract class SwaggerJavaProductsTransmuter extends SwaggerJavaClassesTransmute
   public ResponseEntity<Object> productMemberOfOf(String identifier, @Valid List<String> fields,
       @Min(0) @Valid Integer limit, @Valid List<String> sort, @Valid List<String> searchAfter) {
     return this.processs(new Member(false, true),
-        this.uriParametersBuilder.setIdentifier(identifier).setFields(fields).setLimit(limit)
+        this.uriParametersBuilder.setIdentifier(PdsProductIdentifier.fromString(identifier)).setFields(fields).setLimit(limit)
             .setSort(sort).setSearchAfter(sort, searchAfter).build());
   }
 
@@ -60,7 +61,7 @@ abstract class SwaggerJavaProductsTransmuter extends SwaggerJavaClassesTransmute
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
       @Valid List<String> searchAfter) {
     return this.processs(new Member(false, true),
-        this.uriParametersBuilder.setIdentifier(identifier).setFields(fields).setLimit(limit)
+        this.uriParametersBuilder.setIdentifier(PdsProductIdentifier.fromString(identifier)).setFields(fields).setLimit(limit)
             .setSort(sort).setSearchAfter(sort, searchAfter).setVersion(versions).build());
   }
 
@@ -69,7 +70,7 @@ abstract class SwaggerJavaProductsTransmuter extends SwaggerJavaClassesTransmute
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
       @Valid List<String> searchAfter) {
     return this.processs(new Member(false, false),
-        this.uriParametersBuilder.setIdentifier(identifier).setFields(fields).setLimit(limit)
+        this.uriParametersBuilder.setIdentifier(PdsProductIdentifier.fromString(identifier)).setFields(fields).setLimit(limit)
             .setSort(sort).setSearchAfter(sort, searchAfter).setVersion(versions).build());
   }
 
@@ -77,14 +78,14 @@ abstract class SwaggerJavaProductsTransmuter extends SwaggerJavaClassesTransmute
   public ResponseEntity<Object> productMembers(String identifier, @Valid List<String> fields,
       @Min(0) @Valid Integer limit, @Valid List<String> sort, @Valid List<String> searchAfter) {
     return this.processs(new Member(true, false),
-        this.uriParametersBuilder.setIdentifier(identifier).setFields(fields).setLimit(limit)
+        this.uriParametersBuilder.setIdentifier(PdsProductIdentifier.fromString(identifier)).setFields(fields).setLimit(limit)
             .setSort(sort).setSearchAfter(sort, searchAfter).build());
   }
 
   @Override
   public ResponseEntity<Object> productMembersMembers(String identifier, @Valid List<String> fields,
       @Min(0) @Valid Integer limit, @Valid List<String> sort, @Valid List<String> searchAfter) {
-    return this.processs(new Member(true, true), this.uriParametersBuilder.setIdentifier(identifier)
+    return this.processs(new Member(true, true), this.uriParametersBuilder.setIdentifier(PdsProductIdentifier.fromString(identifier))
         .setFields(fields).setLimit(limit).setSort(sort).setSearchAfter(sort, searchAfter).build());
   }
 
@@ -93,7 +94,7 @@ abstract class SwaggerJavaProductsTransmuter extends SwaggerJavaClassesTransmute
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
       @Valid List<String> searchAfter) {
     return this.processs(new Member(true, true),
-        this.uriParametersBuilder.setIdentifier(identifier).setFields(fields).setLimit(limit)
+        this.uriParametersBuilder.setIdentifier(PdsProductIdentifier.fromString(identifier)).setFields(fields).setLimit(limit)
             .setSort(sort).setSearchAfter(sort, searchAfter).setVersion(versions).build());
   }
 
@@ -102,28 +103,28 @@ abstract class SwaggerJavaProductsTransmuter extends SwaggerJavaClassesTransmute
       @Valid List<String> fields, @Min(0) @Valid Integer limit, @Valid List<String> sort,
       @Valid List<String> searchAfter) {
     return this.processs(new Member(true, false),
-        this.uriParametersBuilder.setIdentifier(identifier).setFields(fields).setLimit(limit)
+        this.uriParametersBuilder.setIdentifier(PdsProductIdentifier.fromString(identifier)).setFields(fields).setLimit(limit)
             .setSort(sort).setSearchAfter(sort, searchAfter).setVersion(versions).build());
   }
 
   @Override
   public ResponseEntity<Object> selectByLidvid(String identifier, @Valid List<String> fields) {
     return this.processs(new Standard(),
-        this.uriParametersBuilder.setIdentifier(identifier).setFields(fields).build());
+        this.uriParametersBuilder.setIdentifier(PdsProductIdentifier.fromString(identifier)).setFields(fields).build());
   }
 
   @Override
   public ResponseEntity<Object> selectByLidvidAll(String identifier, @Valid List<String> fields,
       @Min(0) @Valid Integer limit, @Valid List<String> sort, @Valid List<String> searchAfter) {
     return this.processs(new Standard(),
-        this.uriParametersBuilder.setIdentifier(identifier).setFields(fields).setLimit(limit)
+        this.uriParametersBuilder.setIdentifier(PdsProductIdentifier.fromString(identifier)).setFields(fields).setLimit(limit)
             .setSort(sort).setSearchAfter(sort, searchAfter).setVersion(ProductVersionSelector.ALL).build());
   }
 
   @Override
   public ResponseEntity<Object> selectByLidvidLatest(String identifier,
       @Valid List<String> fields) {
-    return this.processs(new Standard(), this.uriParametersBuilder.setIdentifier(identifier)
+    return this.processs(new Standard(), this.uriParametersBuilder.setIdentifier(PdsProductIdentifier.fromString(identifier))
         .setFields(fields).setVersion(ProductVersionSelector.LATEST).build());
   }
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
@@ -35,7 +35,7 @@ class URIParameters implements UserContext {
   private final String accept;
   private final List<String> fields;
   private final String group;
-  private final String identifier;
+  private final PdsProductIdentifier identifier;
   private final List<String> keywords;
   private final List<String> searchAfterValues;
   private final Integer limit;
@@ -89,7 +89,7 @@ class URIParameters implements UserContext {
   }
 
   @Override
-  public String getIdentifier() {
+  public PdsProductIdentifier getIdentifier() {
     return identifier;
   }
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParametersBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParametersBuilder.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import gov.nasa.pds.api.registry.UserContext;
+import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 
 import gov.nasa.pds.api.registry.UserContext;
 import java.util.stream.Collectors;
@@ -25,7 +26,7 @@ public class URIParametersBuilder {
   public String accept = "application/json";
   public List<String> fields = new ArrayList<String>();
   public String group = "";
-  public String identifier = "";
+  public PdsProductIdentifier identifier = null;
   public List<String> keywords = new ArrayList<String>();
   public List<String> searchAfter = null;
   public Integer limit = 0; // Actual default value is passed in from the upstream frames of the
@@ -62,9 +63,8 @@ public class URIParametersBuilder {
     return this;
   }
 
-  public URIParametersBuilder setIdentifier(String identifier) {
-    if (identifier != null)
-      this.identifier = identifier;
+  public URIParametersBuilder setIdentifier(PdsProductIdentifier identifier) {
+    this.identifier = identifier;
     return this;
   }
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParametersBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParametersBuilder.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import gov.nasa.pds.api.registry.UserContext;
+
+import gov.nasa.pds.api.registry.UserContext;
 import java.util.stream.Collectors;
 
 import gov.nasa.pds.api.registry.model.SearchUtil;

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicAny.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicAny.java
@@ -58,7 +58,7 @@ class RefLogicAny implements ReferencingLogic {
    */
   RequestAndResponseContext rrContextFromConstraint(ControlContext ctrlContext, UserContext userContext, GroupConstraint constraint) throws IOException, ApplicationTypeException, LidVidNotFoundException {
     // Reset identifier to prevent it being applied as a filter during query, which would result in zero hits
-    UserContext newUserContext = URIParametersBuilder.fromInstance(userContext).setIdentifier("").build();
+    UserContext newUserContext = URIParametersBuilder.fromInstance(userContext).setIdentifier(null).build();
 
     RequestAndResponseContext rrContext =
             RequestAndResponseContext.buildRequestAndResponseContext(

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
+import gov.nasa.pds.api.registry.model.identifiers.PdsLid;
 import gov.nasa.pds.api.registry.model.identifiers.PdsLidVid;
 import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 import gov.nasa.pds.api.registry.search.HitIterator;
@@ -81,8 +82,9 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic {
             Set<String> lidReferences = refStrings.stream().filter(PdsProductIdentifier::stringIsLid).collect(Collectors.toSet());
             for (String lidRef : lidReferences) {
               try {
-                String latestLidvidRef = LidVidUtils.getLatestLidVidByLid(ctrlContext, RequestBuildContextFactory.given(true, "_id"), lidRef).toString();
-                lidvidReferences.add(latestLidvidRef);
+                PdsLid lid = PdsLid.fromString(lidRef);
+                PdsLidVid latestLidvid = LidVidUtils.getLatestLidVidByLid(ctrlContext, RequestBuildContextFactory.given(true, "_id"), lid);
+                lidvidReferences.add(latestLidvid.toString());
               } catch (IOException | LidVidNotFoundException e) {
                 log.warn("Failed to find extant LIDVID for given LID: " + lidRef);
               }

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
@@ -119,7 +119,7 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic {
   @Override
   public RequestAndResponseContext memberOf(ControlContext context, UserContext input,
       boolean twoSteps) throws MembershipException {
-    throw new MembershipException(input.getIdentifier(), "member-of", "bundle");
+    throw new MembershipException(input.getIdentifier().toString(), "member-of", "bundle");
   }
 
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
@@ -13,6 +13,8 @@ import gov.nasa.pds.api.registry.ControlContext;
 import gov.nasa.pds.api.registry.GroupConstraint;
 import gov.nasa.pds.api.registry.ReferencingLogic;
 import gov.nasa.pds.api.registry.UserContext;
+import gov.nasa.pds.api.registry.model.identifiers.PdsLid;
+import gov.nasa.pds.api.registry.model.identifiers.PdsLidVid;
 import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 import gov.nasa.pds.api.registry.search.QuickSearch;
 import org.slf4j.Logger;
@@ -66,22 +68,23 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic {
     if (twoSteps)
       throw new MembershipException(searchContext.getIdentifier().toString(), "member-of/member-of", "collections");
 
-    List<String> parentIds = QuickSearch.getValues(ctrlContext.getConnection(), false, searchContext.getLidVid(), "ops:Provenance/ops:parent_bundle_identifier");
+    List<String> parentIdStrings = QuickSearch.getValues(ctrlContext.getConnection(), false, searchContext.getLidVid(), "ops:Provenance/ops:parent_bundle_identifier");
 
-//    Get all the LIDVID refs, convert the LID refs to LIDVIDs, then add them all together
-    Set<String> parentLidvids = parentIds.stream().filter(PdsProductIdentifier::stringIsLidvid).collect(Collectors.toSet());
-    List<String> parentLids = parentIds.stream().filter(PdsProductIdentifier::stringIsLid).collect(Collectors.toList());
-    List<String> implicitParentLidvids =
+//    Get all the LIDVID strings, convert the LID strings to LIDVID strings, then add them all together
+    Set<String> parentLidvidStrings = parentIdStrings.stream().filter(PdsProductIdentifier::stringIsLidvid).collect(Collectors.toSet());
+    List<PdsLid> parentLids = parentIdStrings.stream().map(PdsLid::fromString).filter(PdsLid::isLid).collect(Collectors.toList());
+    List<PdsLidVid> implicitParentLidvids =
             getAllLidVidsByLids(
                     ctrlContext,
                     RequestBuildContextFactory.given(
                             false, "lid", ReferencingLogicTransmuter.Bundle.impl().constraints()),
                     parentLids);
-    parentLidvids.addAll(implicitParentLidvids);
+    List<String> implicitParentLidvidStrings = implicitParentLidvids.stream().map(PdsLidVid::toString).collect(Collectors.toList());
+    parentLidvidStrings.addAll(implicitParentLidvidStrings);
 
     GroupConstraint productClassConstraints = ReferencingLogicTransmuter.NonAggregateProduct.impl().constraints();
     GroupConstraint parentSelectorConstraint =
-            GroupConstraintImpl.buildAny(Map.of("_id", new ArrayList<>(parentLidvids)));
+            GroupConstraintImpl.buildAny(Map.of("_id", new ArrayList<>(parentLidvidStrings)));
     productClassConstraints.union(parentSelectorConstraint);
 
     return rrContextFromConstraint(ctrlContext, searchContext, parentSelectorConstraint);

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
@@ -44,7 +44,7 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic {
       ControlContext ctrlContext, UserContext userContext, boolean twoSteps)
       throws ApplicationTypeException, IOException, LidVidNotFoundException, MembershipException {
     if (twoSteps)
-      throw new MembershipException(userContext.getIdentifier(), "members/members", "collections");
+      throw new MembershipException(userContext.getIdentifier().toString(), "members/members", "collections");
     GroupConstraint childrenConstraint = getChildProductsConstraint(ctrlContext, userContext.getLidVid());
 
     return rrContextFromConstraint(ctrlContext, userContext, childrenConstraint);
@@ -64,7 +64,7 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic {
       boolean twoSteps) throws ApplicationTypeException, IOException, LidVidNotFoundException,
       MembershipException {
     if (twoSteps)
-      throw new MembershipException(searchContext.getIdentifier(), "member-of/member-of", "collections");
+      throw new MembershipException(searchContext.getIdentifier().toString(), "member-of/member-of", "collections");
 
     List<String> parentIds = QuickSearch.getValues(ctrlContext.getConnection(), false, searchContext.getLidVid(), "ops:Provenance/ops:parent_bundle_identifier");
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicNonAggregateProduct.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicNonAggregateProduct.java
@@ -65,24 +65,26 @@ class RefLogicNonAggregateProduct extends RefLogicAny implements ReferencingLogi
 
     //    Get all the LIDVID refs, resolve the LID refs to all relevant LIDVIDs, then add them all
     // together
-    Set<String> parentLidvids =
+    Set<String> parentLidvidStrings =
         ancestorIdentifiers.stream()
             .filter(PdsProductIdentifier::stringIsLidvid)
             .collect(Collectors.toSet());
-    List<String> parentLids =
+    List<PdsLid> parentLids =
         ancestorIdentifiers.stream()
-            .filter(PdsProductIdentifier::stringIsLid)
+            .map(PdsLid::fromString)
+            .filter(PdsLid::isLid)
             .collect(Collectors.toList());
-    List<String> implicitParentLidvids =
+    List<PdsLidVid> implicitParentLidvids =
         getAllLidVidsByLids(
             ctrlContext,
             RequestBuildContextFactory.given(false, "lid", ancestorClass.impl().constraints()),
             parentLids);
-    parentLidvids.addAll(implicitParentLidvids);
+    List<String> implicitParentLidvidStrings = implicitParentLidvids.stream().map(PdsLidVid::toString).collect(Collectors.toList());
+    parentLidvidStrings.addAll(implicitParentLidvidStrings);
 
     GroupConstraint ancestorProductTypeContstraints = ancestorClass.impl().constraints();
     GroupConstraint ancestorSelectorConstraint =
-        GroupConstraintImpl.buildAny(Map.of("_id", new ArrayList<>(parentLidvids)));
+        GroupConstraintImpl.buildAny(Map.of("_id", new ArrayList<>(parentLidvidStrings)));
     ancestorProductTypeContstraints.union(ancestorSelectorConstraint);
 
     return rrContextFromConstraint(ctrlContext, searchContext, ancestorSelectorConstraint);

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
@@ -37,9 +37,8 @@ public class LidVidUtils {
   private static final Logger log = LoggerFactory.getLogger(LidVidUtils.class);
 
   public static PdsLidVid getLatestLidVidByLid(ControlContext ctlContext,
-      RequestBuildContext reqContext, String productIdentifier)
+      RequestBuildContext reqContext, PdsLid lid)
       throws IOException, LidVidNotFoundException {
-    PdsLid lid = PdsProductIdentifier.fromString(productIdentifier).getLid();
 
     SearchRequest searchRequest = new SearchRequestFactory(
         RequestConstructionContextFactory.given("lid", lid.toString(), true),
@@ -106,12 +105,12 @@ public class LidVidUtils {
           // to force that kind of resolution.
           result = productIdentifier instanceof PdsLidVid ? productIdentifier
               : LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext,
-                  productIdentifier.getLid().toString());
+                  productIdentifier.getLid());
           break;
         case TYPED:
           result = productIdentifier instanceof PdsLidVid ? productIdentifier
               : LidVidUtils.getLatestLidVidByLid(ctlContext, reqContext,
-                  productIdentifier.getLid().toString());
+                  productIdentifier.getLid());
           break;
         case ORIGINAL:
           throw new LidVidNotFoundException("ProductVersionSelector.ORIGINAL not supported");

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import gov.nasa.pds.api.registry.model.ProductVersionSelector;
 import gov.nasa.pds.api.registry.model.ReferencingLogicTransmuter;
@@ -66,19 +67,20 @@ public class LidVidUtils {
     throw new LidVidNotFoundException(lid.toString());
   }
 
-  public static List<String> getAllLidVidsByLids(ControlContext ctlContext,
-      RequestBuildContext reqContext, Collection<String> lids) throws IOException {
-    List<String> lidvids = new ArrayList<String>();
+  public static List<PdsLidVid> getAllLidVidsByLids(ControlContext ctlContext,
+      RequestBuildContext reqContext, Collection<PdsLid> lids) throws IOException {
+    List<PdsLidVid> lidvids = new ArrayList<>();
 
-    if (0 < lids.size()) {
+    if (!lids.isEmpty()) {
+      List<String> lidStrings = lids.stream().map(PdsLid::toString).collect(Collectors.toList());
       ctlContext.getConnection().getRestHighLevelClient()
           .search(new SearchRequestFactory(
-              RequestConstructionContextFactory.given("lid", new ArrayList<String>(lids), true),
+              RequestConstructionContextFactory.given("lid", new ArrayList<>(lidStrings), true),
               ctlContext.getConnection()).build(reqContext,
                   ctlContext.getConnection().getRegistryIndex()),
               RequestOptions.DEFAULT)
           .getHits().forEach((hit) -> {
-            lidvids.add(hit.getId());
+            lidvids.add(PdsLidVid.fromString(hit.getId()));
           });
     }
     return lidvids;

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
@@ -30,7 +30,7 @@ import gov.nasa.pds.api.registry.search.SearchRequestFactory;
 
 /**
  * Methods to get latest versions of LIDs
- * 
+ *
  * @author karpenko
  */
 public class LidVidUtils {
@@ -85,11 +85,9 @@ public class LidVidUtils {
     return lidvids;
   }
 
-  public static PdsProductIdentifier resolve(String productIdentifierString,
+  public static PdsProductIdentifier resolve(PdsProductIdentifier productIdentifier,
       ProductVersionSelector scope, ControlContext ctlContext, RequestBuildContext reqContext)
       throws IOException, LidVidNotFoundException {
-    PdsProductIdentifier productIdentifier =
-        PdsProductIdentifier.fromString(productIdentifierString);
     PdsProductIdentifier result = null;
 
     if (productIdentifier != null) {


### PR DESCRIPTION
## 🗒️ Summary
Alters outstanding interfaces to use PdsProductIdentifier objects where possible, particularly at function interfaces.
This provides additional type checking and functionality, as it's clear exactly what a product identifier is and isn't.

## ⚙️ Test Data and/or Report
Manually tested (pending).  Will be covered by automated tests for #396 and #397 

## ♻️ Related Issues
Code quality change - no specific issue