### PR TITLE
411 Removes dependency on immature "alternate_ids" product property

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/LidvidsContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/LidvidsContext.java
@@ -3,7 +3,7 @@ package gov.nasa.pds.api.registry;
 import java.util.List;
 
 public interface LidvidsContext {
-  public String getLidVid();
+  public String getProductIdentifierStr();
 
   public Integer getLimit();
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/Member.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/Member.java
@@ -35,7 +35,7 @@ class Member implements EndpointHandler {
       transmuter = ReferencingLogicTransmuter.getBySwaggerGroup(content.getGroup()).impl();
     else
       transmuter = ReferencingLogicTransmuter.getByProductClass(QuickSearch
-          .getValue(control.getConnection(), false, content.getLidVid(), "product_class")).impl();
+          .getValue(control.getConnection(), false, content.getProductIdentifierStr(), "product_class")).impl();
 
     RequestAndResponseContext context =
         this.offspring ? transmuter.member(control, content, this.twoSteps)

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/URIParameters.java
@@ -109,7 +109,7 @@ class URIParameters implements UserContext {
   }
 
   @Override
-  public String getLidVid() {
+  public String getProductIdentifierStr() {
     return productIdentifier != null ? productIdentifier.toString() : "";
   }
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
@@ -102,14 +102,14 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic {
   public RequestAndResponseContext member(ControlContext ctrlContext, UserContext searchContext,
       boolean twoSteps) throws ApplicationTypeException, IOException, LidVidNotFoundException, UnknownGroupNameException {
 
-    List<String> collectionLidvids = getAllBundleCollectionLidVids(ctrlContext, PdsLidVid.fromString(searchContext.getLidVid()));
+    List<String> collectionLidvids = getAllBundleCollectionLidVids(ctrlContext, PdsLidVid.fromString(searchContext.getProductIdentifierStr()));
     GroupConstraint collectionMemberSelector = GroupConstraintImpl.buildAny(Map.of("_id", collectionLidvids));
     if (twoSteps) {
 //      Current behaviour is to return all non-aggregate products referencing this bundle's LID or LIDVID as a parent.
 //      This may not be desirable as it *may* end up inconsistent with "the member products of the collections returned
 //      by the non-twoSteps query", but this is simple to change later once desired behaviour is ironed out.
       GroupConstraint nonAggregateSelector = ReferencingLogicTransmuter.getBySwaggerGroup("non-aggregate-products").impl().constraints();
-      List<String> bundleAlternateIds = QuickSearch.getValues(ctrlContext.getConnection(), false, searchContext.getLidVid(), "alternate_ids");
+      List<String> bundleAlternateIds = QuickSearch.getValues(ctrlContext.getConnection(), false, searchContext.getProductIdentifierStr(), "alternate_ids");
       GroupConstraint memberSelector = GroupConstraintImpl.buildAny(Map.of("ops:Provenance/ops:parent_bundle_identifier", bundleAlternateIds));
       GroupConstraint nonAggregateMemberSelector = nonAggregateSelector.union(memberSelector);
       return rrContextFromConstraint(ctrlContext, searchContext, nonAggregateMemberSelector);

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicBundle.java
@@ -106,12 +106,10 @@ class RefLogicBundle extends RefLogicAny implements ReferencingLogic {
     List<String> collectionLidvidStrs = collectionLidvids.stream().map(PdsLidVid::toString).collect(Collectors.toList());
     GroupConstraint collectionMemberSelector = GroupConstraintImpl.buildAny(Map.of("_id", collectionLidvidStrs));
     if (twoSteps) {
-//      Current behaviour is to return all non-aggregate products referencing this bundle's LID or LIDVID as a parent.
-//      This may not be desirable as it *may* end up inconsistent with "the member products of the collections returned
-//      by the non-twoSteps query", but this is simple to change later once desired behaviour is ironed out.
       GroupConstraint nonAggregateSelector = ReferencingLogicTransmuter.getBySwaggerGroup("non-aggregate-products").impl().constraints();
-      List<String> bundleAlternateIds = QuickSearch.getValues(ctrlContext.getConnection(), false, searchContext.getProductIdentifierStr(), "alternate_ids");
-      GroupConstraint memberSelector = GroupConstraintImpl.buildAny(Map.of("ops:Provenance/ops:parent_bundle_identifier", bundleAlternateIds));
+      PdsLidVid parentBundleLidvid = PdsLidVid.fromString(searchContext.getProductIdentifierStr());
+      List<String> parentBundleConstraintValues = List.of(parentBundleLidvid.toString());
+      GroupConstraint memberSelector = GroupConstraintImpl.buildAny(Map.of("ops:Provenance/ops:parent_bundle_identifier", parentBundleConstraintValues));
       GroupConstraint nonAggregateMemberSelector = nonAggregateSelector.union(memberSelector);
       return rrContextFromConstraint(ctrlContext, searchContext, nonAggregateMemberSelector);
     } else {

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
@@ -47,7 +47,7 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic {
       throws ApplicationTypeException, IOException, LidVidNotFoundException, MembershipException {
     if (twoSteps)
       throw new MembershipException(userContext.getIdentifier().toString(), "members/members", "collections");
-    GroupConstraint childrenConstraint = getChildProductsConstraint(ctrlContext, userContext.getLidVid());
+    GroupConstraint childrenConstraint = getChildProductsConstraint(ctrlContext, userContext.getProductIdentifierStr());
 
     return rrContextFromConstraint(ctrlContext, userContext, childrenConstraint);
   }
@@ -68,7 +68,7 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic {
     if (twoSteps)
       throw new MembershipException(searchContext.getIdentifier().toString(), "member-of/member-of", "collections");
 
-    List<String> parentIdStrings = QuickSearch.getValues(ctrlContext.getConnection(), false, searchContext.getLidVid(), "ops:Provenance/ops:parent_bundle_identifier");
+    List<String> parentIdStrings = QuickSearch.getValues(ctrlContext.getConnection(), false, searchContext.getProductIdentifierStr(), "ops:Provenance/ops:parent_bundle_identifier");
 
 //    Get all the LIDVID strings, convert the LID strings to LIDVID strings, then add them all together
     Set<String> parentLidvidStrings = parentIdStrings.stream().filter(PdsProductIdentifier::stringIsLidvid).collect(Collectors.toSet());

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicCollection.java
@@ -47,17 +47,16 @@ class RefLogicCollection extends RefLogicAny implements ReferencingLogic {
       throws ApplicationTypeException, IOException, LidVidNotFoundException, MembershipException {
     if (twoSteps)
       throw new MembershipException(userContext.getIdentifier().toString(), "members/members", "collections");
-    GroupConstraint childrenConstraint = getChildProductsConstraint(ctrlContext, userContext.getProductIdentifierStr());
+    PdsLidVid collectionLidvid = PdsLidVid.fromString(userContext.getProductIdentifierStr());
+    GroupConstraint childrenConstraint = getChildProductsConstraint(ctrlContext, collectionLidvid);
 
     return rrContextFromConstraint(ctrlContext, userContext, childrenConstraint);
   }
 
-  private GroupConstraint getChildProductsConstraint(ControlContext control, String parentCollectionLidvid) throws IOException, LidVidNotFoundException {
-//    TODO: targetProductAlternateIds should depend on all/latest/specific behaviour
-    List<String> targetProductAlternateIds = QuickSearch.getValues(control.getConnection(), false, parentCollectionLidvid, "alternate_ids");
-
+  private GroupConstraint getChildProductsConstraint(ControlContext control, PdsLidVid parentCollectionLidvid) throws IOException, LidVidNotFoundException {
+    List<String> parentCollectionConstraintValues = List.of(parentCollectionLidvid.toString());
     GroupConstraint productClassConstraints = ReferencingLogicTransmuter.NonAggregateProduct.impl().constraints();
-    GroupConstraint childrenSelectorConstraint = GroupConstraintImpl.buildAny(Map.of("ops:Provenance/ops:parent_collection_identifier", targetProductAlternateIds));
+    GroupConstraint childrenSelectorConstraint = GroupConstraintImpl.buildAny(Map.of("ops:Provenance/ops:parent_collection_identifier", parentCollectionConstraintValues));
     return productClassConstraints.union(childrenSelectorConstraint);
   }
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicNonAggregateProduct.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RefLogicNonAggregateProduct.java
@@ -3,18 +3,14 @@ package gov.nasa.pds.api.registry.model;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import gov.nasa.pds.api.registry.RequestBuildContext;
 import gov.nasa.pds.api.registry.UserContext;
 import gov.nasa.pds.api.registry.exceptions.ApplicationTypeException;
-import gov.nasa.pds.api.registry.model.identifiers.LidVidUtils;
 import gov.nasa.pds.api.registry.model.identifiers.PdsLid;
 import gov.nasa.pds.api.registry.model.identifiers.PdsLidVid;
 import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
@@ -26,13 +22,9 @@ import com.google.errorprone.annotations.Immutable;
 
 import gov.nasa.pds.api.registry.ControlContext;
 import gov.nasa.pds.api.registry.GroupConstraint;
-import gov.nasa.pds.api.registry.LidvidsContext;
 import gov.nasa.pds.api.registry.ReferencingLogic;
 import gov.nasa.pds.api.registry.exceptions.LidVidNotFoundException;
-import gov.nasa.pds.api.registry.search.HitIterator;
 import gov.nasa.pds.api.registry.search.RequestBuildContextFactory;
-import gov.nasa.pds.api.registry.search.RequestConstructionContextFactory;
-import gov.nasa.pds.api.registry.search.SearchRequestFactory;
 import gov.nasa.pds.api.registry.util.GroupConstraintImpl;
 
 import static gov.nasa.pds.api.registry.model.identifiers.LidVidUtils.getAllLidVidsByLids;
@@ -61,7 +53,7 @@ class RefLogicNonAggregateProduct extends RefLogicAny implements ReferencingLogi
 
     List<String> ancestorIdentifiers =
         QuickSearch.getValues(
-            ctrlContext.getConnection(), false, searchContext.getLidVid(), ancestorMetadataKey);
+            ctrlContext.getConnection(), false, searchContext.getProductIdentifierStr(), ancestorMetadataKey);
 
     //    Get all the LIDVID refs, resolve the LID refs to all relevant LIDVIDs, then add them all
     // together

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/Unlimited.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/Unlimited.java
@@ -12,7 +12,7 @@ class Unlimited implements LidvidsContext {
   }
 
   @Override
-  public String getLidVid() {
+  public String getProductIdentifierStr() {
     return this.lidvid;
   }
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/identifiers/LidVidUtils.java
@@ -131,12 +131,12 @@ public class LidVidUtils {
 
     if (expected_rlt != ReferencingLogicTransmuter.Any) {
       String actual_group =
-          QuickSearch.getValue(control.getConnection(), false, user.getLidVid(), "product_class");
+          QuickSearch.getValue(control.getConnection(), false, user.getProductIdentifierStr(), "product_class");
       ReferencingLogicTransmuter actual_rlt =
           ReferencingLogicTransmuter.getByProductClass(actual_group);
 
       if (actual_rlt != expected_rlt)
-        throw new LidVidMismatchException(user.getLidVid(), user.getGroup(), actual_group);
+        throw new LidVidMismatchException(user.getProductIdentifierStr(), user.getGroup(), actual_group);
     }
   }
 }


### PR DESCRIPTION
## 🗒️ Summary
`alternate_ids` property was used when resolving collection lidvids for both collection member and bundle member/member queries.

This property is not currently maintained in a way that fulfills its assumed purpose.  This PR removes use of the property, and (because only LIDVIDs are supported in this context) replaces use of string identifiers with `PdsLidVid` objects instead.  If any exceptions are experienced as a result of this change, it indicates an issue elsewhere in the code and exposing that issue is desirable.

## ⚙️ Test Data and/or Report
Tested hits count for both a bundle/member/member query and collection/member query and confirmed same number of hits before/after change.

Tested with both LID and LIDVID identifier in path parameter to confirm that LIDs are correctly resolved to latest-LIDVID as expected.

Tested failing example from #411 to ensure it is now succeeding (with zero hits, as expected, as referenced products are not harvested per @jordanpadams )

## ♻️ Related Issues
Fixes #411 


