### PR TITLE
normalize whitespace in log messages outputting user-provided parameters

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
@@ -80,7 +80,7 @@ public class SwaggerJavaTransmuter extends SwaggerJavaHealthcheckTransmuter
           HttpStatus.INTERNAL_SERVER_ERROR);
     } catch (LidVidMismatchException e) {
       log.warn("The lid(vid) (whitespace-normalized) '" + StringUtils.normalizeSpace(parameters.getIdentifier().toString())
-          + "' in the data base type does not match given type () '" + StringUtils.normalizeSpace(parameters.getGroup()) + "'");
+          + "' in the data base type does not match given type '" + StringUtils.normalizeSpace(parameters.getGroup()) + "'");
       return new ResponseEntity<Object>(this.errorMessageFactory.get(e), HttpStatus.NOT_FOUND);
     } catch (LidVidNotFoundException e) {
       log.warn("Could not find lid(vid) in database (whitespace-normalized): " + StringUtils.normalizeSpace(parameters.getIdentifier().toString()));

--- a/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controller/SwaggerJavaTransmuter.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import org.antlr.v4.runtime.NoViableAltException;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -78,11 +79,11 @@ public class SwaggerJavaTransmuter extends SwaggerJavaHealthcheckTransmuter
       return new ResponseEntity<Object>(this.errorMessageFactory.get(e),
           HttpStatus.INTERNAL_SERVER_ERROR);
     } catch (LidVidMismatchException e) {
-      log.warn("The lid(vid) '" + parameters.getIdentifier()
-          + "' in the data base type does not match given type '" + parameters.getGroup() + "'");
+      log.warn("The lid(vid) (whitespace-normalized) '" + StringUtils.normalizeSpace(parameters.getIdentifier().toString())
+          + "' in the data base type does not match given type () '" + StringUtils.normalizeSpace(parameters.getGroup()) + "'");
       return new ResponseEntity<Object>(this.errorMessageFactory.get(e), HttpStatus.NOT_FOUND);
     } catch (LidVidNotFoundException e) {
-      log.warn("Could not find lid(vid) in database: " + parameters.getIdentifier());
+      log.warn("Could not find lid(vid) in database (whitespace-normalized): " + StringUtils.normalizeSpace(parameters.getIdentifier().toString()));
       return new ResponseEntity<Object>(this.errorMessageFactory.get(e), HttpStatus.NOT_FOUND);
     } catch (MembershipException e) {
       log.warn("The given lid(vid) does not support the requested membership.");
@@ -91,7 +92,7 @@ public class SwaggerJavaTransmuter extends SwaggerJavaHealthcheckTransmuter
       log.warn("Could not find any matching reference(s) in database.");
       return new ResponseEntity<Object>(this.errorMessageFactory.get(e), HttpStatus.NOT_FOUND);
     } catch (NoViableAltException | ParseCancellationException e) {
-      log.warn("The given search string '" + parameters.getQuery() + "' cannot be parsed.");
+      log.warn("The given search string (whitespace-normalized) '" + StringUtils.normalizeSpace(parameters.getQuery()) + "' cannot be parsed.");
       ParseCancellationException forwarded_exception = new ParseCancellationException(
           "The given search string '" + parameters.getQuery() + "' cannot be parsed.");
       return new ResponseEntity<Object>(this.errorMessageFactory.get(forwarded_exception),

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/RequestAndResponseContext.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/RequestAndResponseContext.java
@@ -6,6 +6,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
@@ -256,19 +258,19 @@ public class RequestAndResponseContext implements RequestBuildContext, RequestCo
 
     if (response == null) {
       log.warn("Could not find any data given these conditions");
-      log.warn("   fields: " + String.valueOf(this.getFields().size()));
+      log.warn("   fields (whitespace-normalized): " + String.valueOf(this.getFields().size()));
       for (String field : this.getFields())
-        log.warn("      " + field);
-      log.warn("   keyword: " + String.valueOf(this.getKeywords().size()));
+        log.warn("      " + StringUtils.normalizeSpace(field));
+      log.warn("   keyword (whitespace-normalized): " + String.valueOf(this.getKeywords().size()));
       for (String keyword : this.getKeywords())
-        log.warn("    " + keyword);
-      log.warn("   lidvid: " + this.getProductIdentifierString());
+        log.warn("    " + StringUtils.normalizeSpace(keyword));
+      log.warn("   lidvid (whitespace-normalized): " + StringUtils.normalizeSpace(this.getProductIdentifierString()));
       log.warn("   limit: " + String.valueOf(this.getLimit()));
       log.warn("   query string: " + String.valueOf(this.getQueryString()));
       log.warn("   selector: " + String.valueOf(this.getSelector()));
-      log.warn("   sorting: " + String.valueOf(this.getSort().size()));
+      log.warn("   sorting (whitespace-normalized): " + String.valueOf(this.getSort().size()));
       for (String sort : this.getSort())
-        log.warn("      " + sort);
+        log.warn("      " + StringUtils.normalizeSpace(sort));
       log.warn("   searchAfter: " + String.valueOf(this.getSearchAfter()));
       throw new NothingFoundException();
     }


### PR DESCRIPTION
## 🗒️ Summary
Applies `StringUtils.normalizeSpace()` to user-provided values when echoed to log output, to address CRLF injection concerns.

There's probably a way of configuring the logger to perform this automatically, but we're running quick and dirty today, lads.

## ⚙️ Test Data and/or Report
n/a

## ♻️ Related Issues
Fixes #388 