### PR TITLE
Sort search after exceptions

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.Valid;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
@@ -18,15 +17,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import gov.nasa.pds.api.base.ProductsApi;
 import gov.nasa.pds.api.registry.ConnectionContext;
 import gov.nasa.pds.api.registry.model.ErrorMessageFactory;
 import gov.nasa.pds.api.registry.model.exceptions.AcceptFormatNotSupportedException;
-import gov.nasa.pds.api.registry.model.exceptions.MissSortWithSearchAfterException;
+import gov.nasa.pds.api.registry.model.exceptions.SortSearchAfterMismatchException;
 import gov.nasa.pds.api.registry.model.exceptions.NotFoundException;
 import gov.nasa.pds.api.registry.model.exceptions.UnhandledException;
 import gov.nasa.pds.api.registry.model.api_responses.PdsProductBusinessObject;
@@ -216,7 +213,7 @@ public class ProductsController implements ProductsApi {
   @Override
   public ResponseEntity<Object> selectByLidvidAll(String identifier, List<String> fields,
       Integer limit, List<String> sort, List<String> searchAfter) throws UnhandledException,
-      NotFoundException, AcceptFormatNotSupportedException, MissSortWithSearchAfterException {
+      NotFoundException, AcceptFormatNotSupportedException, SortSearchAfterMismatchException {
 
     RawMultipleProductResponse response;
 
@@ -321,7 +318,7 @@ public class ProductsController implements ProductsApi {
 
   private RawMultipleProductResponse getAllLidVid(PdsProductIdentifier identifier,
       List<String> fields, Integer limit, List<String> sort, List<String> searchAfter)
-      throws OpenSearchException, IOException, NotFoundException, MissSortWithSearchAfterException {
+      throws OpenSearchException, IOException, NotFoundException, SortSearchAfterMismatchException {
 
     RegistrySearchRequestBuilder registrySearchRequestBuilder =
         new RegistrySearchRequestBuilder(this.registrySearchRequestBuilder);

--- a/service/src/main/java/gov/nasa/pds/api/registry/controllers/RegistryApiResponseEntityExceptionHandler.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controllers/RegistryApiResponseEntityExceptionHandler.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import gov.nasa.pds.api.registry.model.exceptions.AcceptFormatNotSupportedException;
-import gov.nasa.pds.api.registry.model.exceptions.MissSortWithSearchAfterException;
+import gov.nasa.pds.api.registry.model.exceptions.SortSearchAfterMismatchException;
 import gov.nasa.pds.api.registry.model.exceptions.NotFoundException;
 import gov.nasa.pds.api.registry.model.exceptions.RegistryApiException;
 import gov.nasa.pds.api.registry.model.exceptions.UnhandledException;
@@ -66,9 +66,9 @@ public class RegistryApiResponseEntityExceptionHandler extends ResponseEntityExc
 
   }
 
-  @ExceptionHandler(value = {MissSortWithSearchAfterException.class})
-  protected ResponseEntity<Object> missSort(MissSortWithSearchAfterException ex,
-      WebRequest request) {
+  @ExceptionHandler(value = {SortSearchAfterMismatchException.class})
+  protected ResponseEntity<Object> missSort(SortSearchAfterMismatchException ex,
+                                            WebRequest request) {
     return genericExceptionHandler(ex, request, "", HttpStatus.BAD_REQUEST);
   }
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/exceptions/MissSortWithSearchAfterException.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/exceptions/MissSortWithSearchAfterException.java
@@ -1,8 +1,0 @@
-package gov.nasa.pds.api.registry.model.exceptions;
-
-public class MissSortWithSearchAfterException extends RegistryApiException {
-
-  public MissSortWithSearchAfterException() {
-    super("sort parameter missing, sort is mandatory with search-after");
-  }
-}

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/exceptions/SortSearchAfterMismatchException.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/exceptions/SortSearchAfterMismatchException.java
@@ -1,0 +1,8 @@
+package gov.nasa.pds.api.registry.model.exceptions;
+
+public class SortSearchAfterMismatchException extends RegistryApiException {
+
+  public SortSearchAfterMismatchException(String detail) {
+    super("Invalid combination of sort and searchAfter values: " + detail);
+  }
+}

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
@@ -163,8 +163,10 @@ public class RegistrySearchRequestBuilder {
     this.size(limit);
 
     if ((searchAfter != null) && (!searchAfter.isEmpty())) {
-      if ((sort == null) || (sort.isEmpty())) {
+      if (sort == null) {
         throw new SortSearchAfterMismatchException("sort argument must be provided if searchAfter argument is provided");
+      } else if (searchAfter.size() != sort.size()) {
+        throw new SortSearchAfterMismatchException("sort and searchAfter arguments must be of equal length if provided");
       }
       this.searchAfter(searchAfter);
     }

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
@@ -3,7 +3,7 @@ package gov.nasa.pds.api.registry.search;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
+
 import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CodePointCharStream;
@@ -34,7 +34,7 @@ import gov.nasa.pds.api.registry.lexer.SearchParser;
 import gov.nasa.pds.api.registry.model.Antlr4SearchListener;
 import gov.nasa.pds.api.registry.model.EntityProduct;
 import gov.nasa.pds.api.registry.model.SearchUtil;
-import gov.nasa.pds.api.registry.model.exceptions.MissSortWithSearchAfterException;
+import gov.nasa.pds.api.registry.model.exceptions.SortSearchAfterMismatchException;
 import gov.nasa.pds.api.registry.model.exceptions.UnparsableQParamException;
 import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 
@@ -154,7 +154,7 @@ public class RegistrySearchRequestBuilder {
   }
 
   public RegistrySearchRequestBuilder paginates(Integer limit, List<String> sort,
-      List<String> searchAfter) throws MissSortWithSearchAfterException {
+      List<String> searchAfter) throws SortSearchAfterMismatchException {
 
     if ((sort != null) && (!sort.isEmpty())) {
       this.sort(sort);
@@ -164,7 +164,7 @@ public class RegistrySearchRequestBuilder {
 
     if ((searchAfter != null) && (!searchAfter.isEmpty())) {
       if ((sort == null) || (sort.isEmpty())) {
-        throw new MissSortWithSearchAfterException();
+        throw new SortSearchAfterMismatchException("sort argument must be provided if searchAfter argument is provided");
       }
       this.searchAfter(searchAfter);
     }


### PR DESCRIPTION
## 🗒️ Summary
When checking sort and searchAfter value validity, the presence of arguments for both parameters should be considered invalid if they are of non-equal length.