### PR TITLE
Products endpoint doc update

### DIFF
--- a/model/swagger.yml
+++ b/model/swagger.yml
@@ -142,7 +142,7 @@ paths:
       tags:
         - 1. all products
       summary: |
-        search on all PDS data products, including bundles, collections, documentation, context and observational products.
+        search the latest-versioned instances of all PDS data products, including bundles, collections, documentation, context and observational products.
       operationId: product-list
       responses:
         '200':


### PR DESCRIPTION
## 🗒️ Summary
Trivial swagger doc update - /products only touches the latest-versioned products, yeah @jordanpadams ?


## Applicable requirements
Refs https://github.com/NASA-PDS/registry-api/issues/426
