### PR TITLE
apply onlyLatest() to /products route

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
@@ -252,7 +252,7 @@ public class ProductsController implements ProductsApi {
         new RegistrySearchRequestBuilder(this.registrySearchRequestBuilder);
 
     SearchRequest searchRequest = registrySearchRequestBuilder.addQParam(q)
-        .addKeywordsParam(keywords).fields(fields).paginates(limit, sort, searchAfter).build();
+        .addKeywordsParam(keywords).fields(fields).paginates(limit, sort, searchAfter).onlyLatest().build();
 
     SearchResponse<HashMap> searchResponse =
         this.openSearchClient.search(searchRequest, HashMap.class);


### PR DESCRIPTION
## 🗒️ Summary
`/products` route should only target latest-versioned products

Applies existing `onlyLatest()` build step to existing route control method