### PR TITLE
Fix the get AWS credential schedule decorators

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/SpringBootMain.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/SpringBootMain.java
@@ -7,6 +7,7 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
@@ -17,6 +18,7 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 
 @SpringBootApplication
 @OpenAPIDefinition
+@EnableScheduling
 @ComponentScan(basePackages = {"gov.nasa.pds.api.registry.configuration",
     "gov.nasa.pds.api.registry.controllers", "gov.nasa.pds.api.registry.model",
     "gov.nasa.pds.api.registry.search", "javax.servlet.http"})

--- a/service/src/main/java/gov/nasa/pds/api/registry/util/AWSCredentialsFetcher.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/util/AWSCredentialsFetcher.java
@@ -8,8 +8,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.stereotype.Component;
 import org.springframework.scheduling.annotation.Scheduled;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,8 +54,7 @@ class AWSCredentials {
 }
 
 
-@Configuration
-@EnableScheduling
+@Component
 public class AWSCredentialsFetcher {
 
   private static final Logger log = LoggerFactory.getLogger(AWSCredentialsFetcher.class);
@@ -86,6 +84,7 @@ public class AWSCredentialsFetcher {
         awsCredProperties.setProperty("aws.secretAccessKey", awsCredentials.getSecretAccessKey());
         awsCredProperties.setProperty("aws.sessionToken", awsCredentials.getToken());
         System.setProperties(awsCredProperties);
+        log.info("Expiration of the AWS token is scheduled in " + awsCredentials.expiration);
       } catch (IOException e) {
         log.error("Unable to get or renew AWS Credentials", e);
       }

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -116,12 +116,12 @@ EOF
 
 resource "aws_lb" "registry-api-lb" {
   name               = "registry-api-lb-new"
-  internal           = true
+  internal           = false
   load_balancer_type = "application"
   security_groups    = var.aws_fg_security_groups
   subnets            = var.aws_fg_subnets
 
-  enable_deletion_protection = true
+  enable_deletion_protection = false
 
   access_logs {
     bucket  = var.aws_s3_bucket_logs_id


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This did not work in the dev deployment on AWS.


## ⚙️ Test Data and/or Report
I tested it locally by having a scheduled task every 3 seconds and it worked. I set it back to every 5 hours in the code.


## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


