### PR TITLE
RegistrySearchRequestBuilder redesign

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
@@ -248,7 +248,7 @@ public class ProductsController implements ProductsApi {
     RegistrySearchRequestBuilder registrySearchRequestBuilder =
         new RegistrySearchRequestBuilder(this.registrySearchRequestBuilder);
 
-    SearchRequest searchRequest = registrySearchRequestBuilder.addQParam(q)
+    SearchRequest searchRequest = registrySearchRequestBuilder.constrainByQueryString(q)
         .addKeywordsParam(keywords).fieldsFromStrings(fields).paginates(limit, sort, searchAfter).onlyLatest().build();
 
     SearchResponse<HashMap> searchResponse =

--- a/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
@@ -249,7 +249,7 @@ public class ProductsController implements ProductsApi {
         new RegistrySearchRequestBuilder(this.registrySearchRequestBuilder);
 
     SearchRequest searchRequest = registrySearchRequestBuilder.addQParam(q)
-        .addKeywordsParam(keywords).fields(fields).paginates(limit, sort, searchAfter).onlyLatest().build();
+        .addKeywordsParam(keywords).fieldsFromStrings(fields).paginates(limit, sort, searchAfter).onlyLatest().build();
 
     SearchResponse<HashMap> searchResponse =
         this.openSearchClient.search(searchRequest, HashMap.class);
@@ -272,7 +272,7 @@ public class ProductsController implements ProductsApi {
 
 
     SearchRequest searchRequest =
-        registrySearchRequestBuilder.addLidvidMatch(identifier).fields(fields).build();
+        registrySearchRequestBuilder.addLidvidMatch(identifier).fieldsFromStrings(fields).build();
 
     // useless to detail here that the HashMap is parameterized <String, Object>
     // because of compilation features, see
@@ -297,7 +297,7 @@ public class ProductsController implements ProductsApi {
         new RegistrySearchRequestBuilder(this.registrySearchRequestBuilder);
 
     SearchRequest searchRequest =
-        registrySearchRequestBuilder.addLidMatch(identifier).onlyLatest().fields(fields).build();
+        registrySearchRequestBuilder.addLidMatch(identifier).onlyLatest().fieldsFromStrings(fields).build();
 
     // useless to detail here that the HashMap is parameterized <String, Object>
     // because of compilation features, see
@@ -324,7 +324,7 @@ public class ProductsController implements ProductsApi {
         new RegistrySearchRequestBuilder(this.registrySearchRequestBuilder);
 
     registrySearchRequestBuilder =
-        registrySearchRequestBuilder.addLidMatch(identifier).fields(fields);
+        registrySearchRequestBuilder.addLidMatch(identifier).fieldsFromStrings(fields);
 
     registrySearchRequestBuilder = registrySearchRequestBuilder.paginates(limit, sort, searchAfter);
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
@@ -241,7 +241,7 @@ public class ProductsController implements ProductsApi {
             .constrainByQueryString(q)
             .addKeywordsParam(keywords)
             .fieldsFromStrings(fields)
-            .paginates(limit, sort, searchAfter)
+            .paginate(limit, sort, searchAfter)
             .onlyLatest()
             .build();
 
@@ -314,7 +314,7 @@ public class ProductsController implements ProductsApi {
 
     SearchRequest searchRequest = new RegistrySearchRequestBuilder(this.connectionContext)
             .matchLid(identifier).fieldsFromStrings(fields)
-            .paginates(limit, sort, searchAfter)
+            .paginate(limit, sort, searchAfter)
             .build();
 
     // useless to detail here that the HashMap is parameterized <String, Object>

--- a/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
@@ -272,7 +272,7 @@ public class ProductsController implements ProductsApi {
 
 
     SearchRequest searchRequest =
-        registrySearchRequestBuilder.addLidvidMatch(identifier).fieldsFromStrings(fields).build();
+        registrySearchRequestBuilder.matchLidvid(identifier).fieldsFromStrings(fields).build();
 
     // useless to detail here that the HashMap is parameterized <String, Object>
     // because of compilation features, see
@@ -297,7 +297,7 @@ public class ProductsController implements ProductsApi {
         new RegistrySearchRequestBuilder(this.registrySearchRequestBuilder);
 
     SearchRequest searchRequest =
-        registrySearchRequestBuilder.addLidMatch(identifier).onlyLatest().fieldsFromStrings(fields).build();
+        registrySearchRequestBuilder.matchLid(identifier).onlyLatest().fieldsFromStrings(fields).build();
 
     // useless to detail here that the HashMap is parameterized <String, Object>
     // because of compilation features, see
@@ -324,7 +324,7 @@ public class ProductsController implements ProductsApi {
         new RegistrySearchRequestBuilder(this.registrySearchRequestBuilder);
 
     registrySearchRequestBuilder =
-        registrySearchRequestBuilder.addLidMatch(identifier).fieldsFromStrings(fields);
+        registrySearchRequestBuilder.matchLid(identifier).fieldsFromStrings(fields);
 
     registrySearchRequestBuilder = registrySearchRequestBuilder.paginates(limit, sort, searchAfter);
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
@@ -42,7 +42,6 @@ public class ProductsController implements ProductsApi {
   private static final Logger log = LoggerFactory.getLogger(ProductsController.class);
 
   private final ConnectionContext connectionContext;
-  private final RegistrySearchRequestBuilder registrySearchRequestBuilder;
   private final ErrorMessageFactory errorMessageFactory;
   private final ObjectMapper objectMapper;
   private OpenSearchClient openSearchClient;
@@ -80,14 +79,9 @@ public class ProductsController implements ProductsApi {
   public ProductsController(ConnectionContext connectionContext,
       ErrorMessageFactory errorMessageFactory, ObjectMapper objectMapper) {
 
-    this.connectionContext = connectionContext;
     this.errorMessageFactory = errorMessageFactory;
     this.objectMapper = objectMapper;
-
-
-    this.registrySearchRequestBuilder = new RegistrySearchRequestBuilder(connectionContext);
-
-
+    this.connectionContext = connectionContext;
     this.openSearchClient = this.connectionContext.getOpenSearchClient();
 
   }
@@ -242,14 +236,14 @@ public class ProductsController implements ProductsApi {
   @Override
   public ResponseEntity<Object> productList(List<String> fields, List<String> keywords,
       Integer limit, String q, List<String> sort, List<String> searchAfter) throws Exception {
-    RawMultipleProductResponse response;
 
-
-    RegistrySearchRequestBuilder registrySearchRequestBuilder =
-        new RegistrySearchRequestBuilder(this.registrySearchRequestBuilder);
-
-    SearchRequest searchRequest = registrySearchRequestBuilder.constrainByQueryString(q)
-        .addKeywordsParam(keywords).fieldsFromStrings(fields).paginates(limit, sort, searchAfter).onlyLatest().build();
+    SearchRequest searchRequest = new RegistrySearchRequestBuilder(this.connectionContext)
+            .constrainByQueryString(q)
+            .addKeywordsParam(keywords)
+            .fieldsFromStrings(fields)
+            .paginates(limit, sort, searchAfter)
+            .onlyLatest()
+            .build();
 
     SearchResponse<HashMap> searchResponse =
         this.openSearchClient.search(searchRequest, HashMap.class);
@@ -267,12 +261,10 @@ public class ProductsController implements ProductsApi {
   private HashMap<String, Object> getLidVid(PdsProductIdentifier identifier, List<String> fields)
       throws OpenSearchException, IOException, NotFoundException {
 
-    RegistrySearchRequestBuilder registrySearchRequestBuilder =
-        new RegistrySearchRequestBuilder(this.registrySearchRequestBuilder);
-
-
-    SearchRequest searchRequest =
-        registrySearchRequestBuilder.matchLidvid(identifier).fieldsFromStrings(fields).build();
+    SearchRequest searchRequest = new RegistrySearchRequestBuilder(this.connectionContext)
+            .matchLidvid(identifier)
+            .fieldsFromStrings(fields)
+            .build();
 
     // useless to detail here that the HashMap is parameterized <String, Object>
     // because of compilation features, see
@@ -293,11 +285,11 @@ public class ProductsController implements ProductsApi {
   private HashMap<String, Object> getLatestLidVid(PdsProductIdentifier identifier,
       List<String> fields) throws OpenSearchException, IOException, NotFoundException {
 
-    RegistrySearchRequestBuilder registrySearchRequestBuilder =
-        new RegistrySearchRequestBuilder(this.registrySearchRequestBuilder);
-
-    SearchRequest searchRequest =
-        registrySearchRequestBuilder.matchLid(identifier).onlyLatest().fieldsFromStrings(fields).build();
+    SearchRequest searchRequest = new RegistrySearchRequestBuilder(this.connectionContext)
+            .matchLid(identifier)
+            .fieldsFromStrings(fields)
+            .onlyLatest()
+            .build();
 
     // useless to detail here that the HashMap is parameterized <String, Object>
     // because of compilation features, see
@@ -320,16 +312,10 @@ public class ProductsController implements ProductsApi {
       List<String> fields, Integer limit, List<String> sort, List<String> searchAfter)
       throws OpenSearchException, IOException, NotFoundException, SortSearchAfterMismatchException {
 
-    RegistrySearchRequestBuilder registrySearchRequestBuilder =
-        new RegistrySearchRequestBuilder(this.registrySearchRequestBuilder);
-
-    registrySearchRequestBuilder =
-        registrySearchRequestBuilder.matchLid(identifier).fieldsFromStrings(fields);
-
-    registrySearchRequestBuilder = registrySearchRequestBuilder.paginates(limit, sort, searchAfter);
-
-
-    SearchRequest searchRequest = registrySearchRequestBuilder.build();
+    SearchRequest searchRequest = new RegistrySearchRequestBuilder(this.connectionContext)
+            .matchLid(identifier).fieldsFromStrings(fields)
+            .paginates(limit, sort, searchAfter)
+            .build();
 
     // useless to detail here that the HashMap is parameterized <String, Object>
     // because of compilation features, see

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
@@ -100,20 +100,6 @@ public class RegistrySearchRequestBuilder extends SearchRequest.Builder{
     return mustNot;
   }
 
-  public RegistrySearchRequestBuilder(RegistrySearchRequestBuilder registrySearchRequestBuilder) {
-
-    this.connectionContext = registrySearchRequestBuilder.getConnectionContext();
-    this.registryIndices = registrySearchRequestBuilder.getRegistryIndices();
-
-    this.index(registryIndices);
-
-    this.must = new ArrayList<Query>(registrySearchRequestBuilder.getMust());
-    this.mustNot = new ArrayList<Query>(registrySearchRequestBuilder.getMustNot());
-
-  }
-
-
-
   public RegistrySearchRequestBuilder onlyLatest() {
 
     ExistsQuery supersededByExists =

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
@@ -125,32 +125,35 @@ public class RegistrySearchRequestBuilder extends SearchRequest.Builder{
 
   }
 
-
-  public RegistrySearchRequestBuilder addLidvidMatch(PdsProductIdentifier identifier) {
-    // lidvid match
-    FieldValue lidvidFieldValue =
-        new FieldValue.Builder().stringValue(identifier.toString()).build();
-
-    MatchQuery lidvidMatch = new MatchQuery.Builder().field("_id").query(lidvidFieldValue).build();
+  /**
+   * Add a constraint that a given field name must match the given field value
+   * @param fieldName the name of the field in OpenSearch format
+   * @param value the value which must be present in the given field
+   */
+  public RegistrySearchRequestBuilder mustMatch(String fieldName, String value) {
+    FieldValue fieldValue = new FieldValue.Builder().stringValue(value).build();
+    MatchQuery lidvidMatch = new MatchQuery.Builder().field(fieldName).query(fieldValue).build();
 
     this.must.add(lidvidMatch.toQuery());
 
     return this;
 
   }
+  /**
+   * Add a constraint that a given field name must match the given field value
+   * @param fieldName the name of the field in OpenSearch format
+   * @param identifier the PDS identifier whose string representation must be present in the given field
+   */
+  public RegistrySearchRequestBuilder mustMatch(String fieldName, PdsProductIdentifier identifier) {
+    return this.mustMatch(fieldName, identifier.toString());
+  }
 
+  public RegistrySearchRequestBuilder matchLidvid(PdsProductIdentifier identifier) {
+    return this.mustMatch("_id", identifier);
+  }
 
-  public RegistrySearchRequestBuilder addLidMatch(PdsProductIdentifier identifier) {
-    // lid match
-    FieldValue lidvidFieldValue =
-        new FieldValue.Builder().stringValue(identifier.getLid().toString()).build();
-
-    MatchQuery lidMatch = new MatchQuery.Builder().field("lid").query(lidvidFieldValue).build();
-
-    this.must.add(lidMatch.toQuery());
-
-    return this;
-
+  public RegistrySearchRequestBuilder matchLid(PdsProductIdentifier identifier) {
+    return this.mustMatch("lid", identifier);
   }
 
   public RegistrySearchRequestBuilder paginates(Integer pageSize, List<String> sortFieldNames,

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
@@ -250,16 +250,6 @@ public class RegistrySearchRequestBuilder extends SearchRequest.Builder{
             .build();
   }
 
-
-
-  public ConnectionContext getConnectionContext() {
-    return connectionContext;
-  }
-
-  public List<String> getRegistryIndices() {
-    return registryIndices;
-  }
-
   private static BoolQuery parseQueryString(String queryString) {
     CodePointCharStream input = CharStreams.fromString(queryString);
     SearchLexer lex = new SearchLexer(input);

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
@@ -221,7 +221,12 @@ public class RegistrySearchRequestBuilder extends SearchRequest.Builder{
   }
 
 
-  public RegistrySearchRequestBuilder addQParam(String q) throws UnparsableQParamException {
+  /**
+   * Constrain results with a query-string in PDS API Search Query syntax
+   * @param q a PDS API Search Query string
+   * @throws UnparsableQParamException if the string is not parseable
+   */
+  public RegistrySearchRequestBuilder constrainByQueryString(String q) throws UnparsableQParamException {
 
     try {
       if ((q != null) && (q.length() > 0)) {

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
@@ -62,9 +62,6 @@ public class RegistrySearchRequestBuilder extends SearchRequest.Builder{
   List<Query> must = new ArrayList<Query>();
   List<Query> mustNot = new ArrayList<Query>();
 
-  SearchRequest.Builder searchRequestBuilder = null;
-
-
   public RegistrySearchRequestBuilder(ConnectionContext connectionContext) {
 //    edunn TODO: Evaluate what can be taken out of the constructor
 
@@ -257,10 +254,6 @@ public class RegistrySearchRequestBuilder extends SearchRequest.Builder{
 
   public List<String> getRegistryIndices() {
     return registryIndices;
-  }
-
-  public SearchRequest.Builder getSearchRequestBuilder() {
-    return searchRequestBuilder;
   }
 
   private static BoolQuery parseQueryString(String queryString) {

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
@@ -105,11 +105,10 @@ public class RegistrySearchRequestBuilder extends SearchRequest.Builder{
   }
 
   public SearchRequest build() {
-    Query query = this.queryBuilder.build().toQuery();
-    return super
-            .query(query)
-            .trackTotalHits(t -> t.enabled(true))
-            .build();
+    this.query(this.queryBuilder.build().toQuery());
+    this.trackTotalHits(t -> t.enabled(true));
+
+    return super.build();
   }
 
   /**

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
@@ -121,7 +121,7 @@ public class RegistrySearchRequestBuilder extends SearchRequest.Builder{
    * @param fieldName the name of the field in OpenSearch format
    * @param value the value which must be present in the given field
    */
-  public RegistrySearchRequestBuilder mustMatch(String fieldName, String value) {
+  public RegistrySearchRequestBuilder matchField(String fieldName, String value) {
     FieldValue fieldValue = new FieldValue.Builder().stringValue(value).build();
     MatchQuery lidvidMatch = new MatchQuery.Builder().field(fieldName).query(fieldValue).build();
 
@@ -135,19 +135,19 @@ public class RegistrySearchRequestBuilder extends SearchRequest.Builder{
    * @param fieldName the name of the field in OpenSearch format
    * @param identifier the PDS identifier whose string representation must be present in the given field
    */
-  public RegistrySearchRequestBuilder mustMatch(String fieldName, PdsProductIdentifier identifier) {
-    return this.mustMatch(fieldName, identifier.toString());
+  public RegistrySearchRequestBuilder matchField(String fieldName, PdsProductIdentifier identifier) {
+    return this.matchField(fieldName, identifier.toString());
   }
 
   public RegistrySearchRequestBuilder matchLidvid(PdsProductIdentifier identifier) {
-    return this.mustMatch("_id", identifier);
+    return this.matchField("_id", identifier);
   }
 
   public RegistrySearchRequestBuilder matchLid(PdsProductIdentifier identifier) {
-    return this.mustMatch("lid", identifier);
+    return this.matchField("lid", identifier);
   }
 
-  public RegistrySearchRequestBuilder paginates(Integer pageSize, List<String> sortFieldNames,
+  public RegistrySearchRequestBuilder paginate(Integer pageSize, List<String> sortFieldNames,
       List<String> searchAfterFieldValues) throws SortSearchAfterMismatchException {
     if ((sortFieldNames != null) && (!sortFieldNames.isEmpty())) {
       this.sortFromStrings(sortFieldNames);


### PR DESCRIPTION
## 🗒️ Summary
Revises implementation of RegistrySearchRequestBuilder per earlier discussion with @tloubrieu-jpl 

Our proprietary builder now subclasses `SearchRequest.Builder`, and composes a `BoolQuery.Builder` which is only build when the search request is built.

Documentation added for some functions, but more is needed.

## ⚙️ Test Data and/or Report
I&T tests produce same results vs `develop` - 103 pass, 14 fail
