### PR TITLE
make q= operator, NOT, LIKE, AND, OR antlr tokens case-insensitive

### DIFF
--- a/lexer/src/main/antlr4/gov/nasa/pds/api/registry/lexer/Search.g4
+++ b/lexer/src/main/antlr4/gov/nasa/pds/api/registry/lexer/Search.g4
@@ -10,25 +10,54 @@ comparison : FIELD operator ( NUMBER | STRINGVAL ) ;
 likeComparison : FIELD LIKE STRINGVAL ;
 operator : EQ | NE | GT | GE | LT | LE ;
 
-NOT : 'not' ;
+NOT : 'NOT' | 'not' ;
 
-EQ : 'eq' ;
-NE : 'ne' ;
-GT : 'gt' ;
-GE : 'ge' ;
-LT : 'lt' ;
-LE : 'le' ;
+EQ : E Q ;
+NE : N E ;
+GT : G T ;
+GE : G E ;
+LT : L T ;
+LE : L E ;
 
-LIKE: 'like';
+LIKE: L I K E;
 
 LPAREN : '(' ;
 RPAREN : ')' ;
 
-AND : 'AND' | 'and' ;
-OR  : 'OR' | 'or' ;
+AND : A N D ;
+OR  : O R ;
 
 FIELD     : [A-Za-z_] [A-Za-z0-9_.:/]* ;
 STRINGVAL : '"' ~["\r\n]* '"' ;
 NUMBER :  ('-')? [0-9]+ ('.' [0-9]*)?  ;
 
 WS : [ \t\r\n]+ -> skip ;
+
+
+// case-insensitivity fragments, per https://chromium.googlesource.com/external/github.com/antlr/antlr4/+/2191c386190a7d57d457319dd2f6aec4f0231d4c/doc/case-insensitive-lexing.md
+fragment A : [aA];
+fragment B : [bB];
+fragment C : [cC];
+fragment D : [dD];
+fragment E : [eE];
+fragment F : [fF];
+fragment G : [gG];
+fragment H : [hH];
+fragment I : [iI];
+fragment J : [jJ];
+fragment K : [kK];
+fragment L : [lL];
+fragment M : [mM];
+fragment N : [nN];
+fragment O : [oO];
+fragment P : [pP];
+fragment Q : [qQ];
+fragment R : [rR];
+fragment S : [sS];
+fragment T : [tT];
+fragment U : [uU];
+fragment V : [vV];
+fragment W : [wW];
+fragment X : [xX];
+fragment Y : [yY];
+fragment Z : [zZ];


### PR DESCRIPTION
## 🗒️ Summary
Makes all predefined tokens case-insensitive

@tloubrieu-jpl @jordanpadams can you confirm that the intended behaviour is "case-insensitive" and not "accepts full-uppercase and full-lowercase"?

## ⚙️ Test Data and/or Report
Tests implemented in https://github.com/NASA-PDS/registry/pull/310

@jordanpadams new test cases:

- AND supported
- OR supported
- NOT supported
- lowercase supported

## ♻️ Related Issues
fixes #495 

