### PR TITLE
Fix code scanning alert no. 155: Log Injection

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
@@ -339,7 +339,8 @@ public class RegistrySearchRequestBuilder extends SearchRequest.Builder{
       }
       return this;
     } catch (RecognitionException | ParseCancellationException e) {
-      log.info("Unable to parse q " + q + "error message is " + e);
+      String sanitizedQ = q.replace('\n', ' ').replace('\r', ' ');
+      log.info("Unable to parse q " + sanitizedQ + " error message is " + e);
       throw new UnparsableQParamException(
           "q string value:" + q + " Error message " + e.getMessage());
     }


### PR DESCRIPTION
Fixes [https://github.com/NASA-PDS/registry-api/security/code-scanning/155](https://github.com/NASA-PDS/registry-api/security/code-scanning/155)

To fix the log injection issue, we need to sanitize the user-provided input before logging it. The best way to do this is to remove any potentially harmful characters from the input string. Specifically, we should replace newline characters with spaces to prevent log forging. Additionally, we should ensure that the user input is clearly marked in the log entry to avoid confusion.

1. Sanitize the user-provided input by replacing newline characters with spaces.
2. Update the log message to use the sanitized input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
