### PR TITLE
575 log SearchRequest content in debug logs

### DIFF
--- a/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
@@ -1,5 +1,6 @@
 package gov.nasa.pds.api.registry.search;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -151,21 +152,26 @@ public class RegistrySearchRequestBuilder extends SearchRequest.Builder{
 
     SearchRequest searchRequest = super.build();
 
-    try (StringWriter writer = new StringWriter();) {
-      JsonFactory jsonFactory = new JsonFactory();
-      JsonGenerator jsonGenerator = jsonFactory.createGenerator(writer);
-      jsonGenerator.useDefaultPrettyPrinter();
-
-      JacksonJsonpGenerator jacksonJsonpGenerator = new JacksonJsonpGenerator(jsonGenerator);
-      searchRequest.serialize(jacksonJsonpGenerator, null);
-      jsonGenerator.close();
-      String jsonString = writer.toString();
-      log.debug("Generated OpenSearch SearchRequest with query:\n" + jsonString);
+    try {
+      String requestJson = serializeSearchRequest(searchRequest);
+      log.debug("Generated OpenSearch SearchRequest with query:\n" + requestJson);
     } catch (Exception e) {
-      e.printStackTrace();
+      log.error("Failed to generate json serialization of SearchRequest: " + e);
     }
 
     return searchRequest;
+  }
+
+  public String serializeSearchRequest(SearchRequest searchRequest) throws IOException {
+    StringWriter writer = new StringWriter();
+    JsonFactory jsonFactory = new JsonFactory();
+    JsonGenerator jsonGenerator = jsonFactory.createGenerator(writer);
+    jsonGenerator.useDefaultPrettyPrinter();
+
+    JacksonJsonpGenerator jacksonJsonpGenerator = new JacksonJsonpGenerator(jsonGenerator);
+    searchRequest.serialize(jacksonJsonpGenerator, null);
+    jsonGenerator.close();
+    return writer.toString();
   }
 
   /**

--- a/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/search/RegistrySearchRequestBuilder.java
@@ -1,9 +1,12 @@
 package gov.nasa.pds.api.registry.search;
 
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 import gov.nasa.pds.api.registry.model.identifiers.PdsLidVid;
 import gov.nasa.pds.api.registry.model.identifiers.PdsProductClasses;
 import org.antlr.v4.runtime.BailErrorStrategy;
@@ -15,6 +18,7 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.commons.lang3.StringUtils;
+import org.opensearch.client.json.jackson.JacksonJsonpGenerator;
 import org.opensearch.client.opensearch._types.FieldSort;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOptions;
@@ -141,10 +145,27 @@ public class RegistrySearchRequestBuilder extends SearchRequest.Builder{
   }
 
   public SearchRequest build() {
-    this.query(this.queryBuilder.build().toQuery());
+    BoolQuery bQuery = this.queryBuilder.build();
+    this.query(bQuery.toQuery());
     this.trackTotalHits(t -> t.enabled(true));
 
-    return super.build();
+    SearchRequest searchRequest = super.build();
+
+    try (StringWriter writer = new StringWriter();) {
+      JsonFactory jsonFactory = new JsonFactory();
+      JsonGenerator jsonGenerator = jsonFactory.createGenerator(writer);
+      jsonGenerator.useDefaultPrettyPrinter();
+
+      JacksonJsonpGenerator jacksonJsonpGenerator = new JacksonJsonpGenerator(jsonGenerator);
+      searchRequest.serialize(jacksonJsonpGenerator, null);
+      jsonGenerator.close();
+      String jsonString = writer.toString();
+      log.debug("Generated OpenSearch SearchRequest with query:\n" + jsonString);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    return searchRequest;
   }
 
   /**


### PR DESCRIPTION
## 🗒️ Summary
'nuf said

## ⚙️ Test Data and/or Report
Manually tested, but unable to test with up-to-date code due to #605 

Given a request to http://localhost:8081/products/somerandomproductid::2.1 the following log message is observed:

```
2025-01-23T15:39:31.010-08:00 DEBUG 58257 --- [nio-8081-exec-3] g.n.p.a.r.s.RegistrySearchRequestBuilder : Generated OpenSearch SearchRequest with query:
{
  "query" : {
    "bool" : {
      "must" : [ {
        "terms" : {
          "ops:Tracking_Meta/ops:archive_status" : [ "archived", "certified" ]
        }
      }, {
        "match" : {
          "_id" : {
            "query" : "somerandomproductid::2.1"
          }
        }
      } ]
    }
  },
  "track_total_hits" : true
}
```

## ♻️ Related Issues
fixes #575 


