### PR TITLE
Performance monitoring and improvement

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,8 +41,8 @@
 # Normally we'd prefer Alpine Linux, but JDK 11 isn't available with it, so
 # we go with a slim Debian. Debian's good too.
 
-FROM openjdk:17-slim
-
+#FROM openjdk:17-slim
+FROM tomcat:9.0.58-jdk17-openjdk-slim
 
 # API JAR file
 # ------------

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,6 @@
 # Normally we'd prefer Alpine Linux, but JDK 11 isn't available with it, so
 # we go with a slim Debian. Debian's good too.
 
-#FROM openjdk:17-slim
 FROM tomcat:9.0.58-jdk17-openjdk-slim
 
 # API JAR file
@@ -57,14 +56,12 @@ ARG api_jar
 # Layering
 # --------
 #
-# Add the API JAR file and the libtcnative-1 package—which is needed for
-# some reason.
+# Add the API JAR file and curl to wait for elasticsearch.
 
 ADD $api_jar /usr/local/registry-api-service/registry-api-service.jar
 
 RUN : &&\
     apt-get update --quiet --yes &&\
-    apt-get install --quiet --yes libtcnative-1 &&\
     apt-get install curl -y &&\
     apt-get autoclean --quiet --yes &&\
     rm --recursive --force /var/lib/apt/lists/* &&\
@@ -82,8 +79,8 @@ ARG JAVA_OPTS="-Xmx6144m -Xms512Mb"
 
 WORKDIR /usr/local/registry-api-service
 EXPOSE  ${SERVER_PORT}
-CMD java $JAVA_OPT -jar /usr/local/registry-api-service/registry-api-service.jar \
-    gov.nasa.pds.api.registry.SpringBootMain --server.port=${SERVER_PORT} ${SPRING_BOOT_APP_ARGS}
+CMD ["java",  "$JAVA_OPT",  "-jar",  "/usr/local/registry-api-service/registry-api-service.jar", \
+    "gov.nasa.pds.api.registry.SpringBootMain", "--server.port=${SERVER_PORT}",  "${SPRING_BOOT_APP_ARGS}"]
 
 
 # Labels
@@ -92,6 +89,6 @@ CMD java $JAVA_OPT -jar /usr/local/registry-api-service/registry-api-service.jar
 # `org.label-schema` is deprecated, but no one can figure out whatever
 # replaced it, so we'll use it here.
 
-LABEL "org.label-schema.name" = "PDS Registry API"
-LABEL "org.label-schema.description" = "Planetary Data System's Application Programmer's Interface for the Registry"
-LABEL "org.label-schema.url" = "https://github.com/NASA-PDS/registry-api"
+LABEL "org.label-schema.name" "PDS Registry API"
+LABEL "org.label-schema.description" "Planetary Data System's Application Programmer's Interface for the Registry"
+LABEL "org.label-schema.url" "https://github.com/NASA-PDS/registry-api"

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -480,8 +480,16 @@
 	    <version>6.0.0</version>
 	    <scope>provided</scope>
 	</dependency>
-    
+	
+	<!-- https://mvnrepository.com/artifact/org.springframework/spring-aspects -->
+	<dependency>
+	    <groupId>org.springframework</groupId>
+	    <artifactId>spring-aspects</artifactId>
+	    <version>6.2.5</version>
+	</dependency>
+	
   </dependencies>
+    
 
   <dependencyManagement>
     <dependencies>

--- a/service/src/main/java/gov/nasa/pds/api/registry/SpringBootMain.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/SpringBootMain.java
@@ -21,7 +21,7 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 @EnableScheduling
 @ComponentScan(basePackages = {"gov.nasa.pds.api.registry.configuration",
     "gov.nasa.pds.api.registry.controllers", "gov.nasa.pds.api.registry.model",
-    "gov.nasa.pds.api.registry.search", "javax.servlet.http"})
+    "gov.nasa.pds.api.registry.search", "gov.nasa.pds.api.registry.util", "javax.servlet.http"})
 public class SpringBootMain implements CommandLineRunner {
 
   private static final Logger log = LoggerFactory.getLogger(SpringBootMain.class);

--- a/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
@@ -240,10 +240,7 @@ public class ProductsController implements ProductsApi, ClassesApi, PropertiesAp
         this.openSearchClient.search(searchRequest, HashMap.class);
 
     RawMultipleProductResponse products = new RawMultipleProductResponse(searchResponse);
-    ResponseEntity<Object> response = formatMultipleProducts(products, fields);
-
-    return response;
-
+    return formatMultipleProducts(products, fields);
 
   }
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controllers/ProductsController.java
@@ -46,6 +46,7 @@ import gov.nasa.pds.api.registry.model.api_responses.RawMultipleProductResponse;
 import gov.nasa.pds.api.registry.model.api_responses.WyriwygBusinessObject;
 import gov.nasa.pds.api.registry.model.identifiers.PdsProductIdentifier;
 import gov.nasa.pds.api.registry.search.RegistrySearchRequestBuilder;
+import gov.nasa.pds.api.registry.util.LogExecutionTime;
 import gov.nasa.pds.model.PropertiesListInner;
 
 
@@ -87,7 +88,7 @@ public class ProductsController implements ProductsApi, ClassesApi, PropertiesAp
 
   }
 
-
+  @LogExecutionTime
   private ResponseEntity<Object> formatSingleProduct(HashMap<String, Object> product,
       List<String> fields) throws AcceptFormatNotSupportedException, UnhandledException {
     // TODO add case when Accept is not available, default application/json
@@ -116,6 +117,7 @@ public class ProductsController implements ProductsApi, ClassesApi, PropertiesAp
     }
   }
 
+  @LogExecutionTime
   private ResponseEntity<Object> formatMultipleProducts(RawMultipleProductResponse response,
       List<String> fields) throws AcceptFormatNotSupportedException, UnhandledException {
     // TODO add case when Accept is not available, default application/json
@@ -226,6 +228,7 @@ public class ProductsController implements ProductsApi, ClassesApi, PropertiesAp
   }
 
   @Override
+  @LogExecutionTime
   public ResponseEntity<Object> productList(List<String> fields, List<String> keywords,
       Integer limit, String q, List<String> sort, List<String> searchAfter) throws Exception {
 
@@ -237,8 +240,9 @@ public class ProductsController implements ProductsApi, ClassesApi, PropertiesAp
         this.openSearchClient.search(searchRequest, HashMap.class);
 
     RawMultipleProductResponse products = new RawMultipleProductResponse(searchResponse);
+    ResponseEntity<Object> response = formatMultipleProducts(products, fields);
 
-    return formatMultipleProducts(products, fields);
+    return response;
 
 
   }

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/api_responses/PdsProductBusinessObject.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/api_responses/PdsProductBusinessObject.java
@@ -15,6 +15,7 @@ import gov.nasa.pds.api.registry.model.EntityProduct;
 import gov.nasa.pds.api.registry.model.SearchUtil;
 import gov.nasa.pds.api.registry.model.exceptions.UnauthorizedForwardedHostException;
 import gov.nasa.pds.api.registry.search.HitIterator;
+import gov.nasa.pds.api.registry.util.LogExecutionTime;
 import gov.nasa.pds.model.PdsProduct;
 import gov.nasa.pds.model.PdsProducts;
 import gov.nasa.pds.model.Summary;
@@ -72,6 +73,7 @@ public class PdsProductBusinessObject extends ProductBusinessLogicImpl {
 
   @Override
   @SuppressWarnings("unchecked")
+  @LogExecutionTime
   public void setResponse(List<Map<String, Object>> hits, Summary summary, List<String> fields) {
     PdsProducts products = new PdsProducts();
     Set<String> uniqueProperties = new TreeSet<String>();

--- a/service/src/main/java/gov/nasa/pds/api/registry/util/LogExecutionTime.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/util/LogExecutionTime.java
@@ -1,0 +1,11 @@
+package gov.nasa.pds.api.registry.util;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface LogExecutionTime {
+}

--- a/service/src/main/java/gov/nasa/pds/api/registry/util/LoggingAspect.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/util/LoggingAspect.java
@@ -20,7 +20,7 @@ public class LoggingAspect {
     long startTime = System.currentTimeMillis();
     Object proceed = joinPoint.proceed();
     long endTime = System.currentTimeMillis();
-    logger.info(joinPoint.getSignature() + " executed in " + (endTime - startTime) + "ms");
+    logger.info("{} executed in {} ms", joinPoint.getSignature(), endTime - startTime);
     return proceed;
   }
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/util/LoggingAspect.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/util/LoggingAspect.java
@@ -1,0 +1,28 @@
+package gov.nasa.pds.api.registry.util;
+
+
+import org.springframework.stereotype.Component;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Around;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Aspect
+@Component
+public class LoggingAspect {
+  private Logger logger = LoggerFactory.getLogger(LoggingAspect.class);
+
+  @Around("@annotation(gov.nasa.pds.api.registry.util.LogExecutionTime)")
+  public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+    logger.info("Log execution time through decorator");
+    long startTime = System.currentTimeMillis();
+    Object proceed = joinPoint.proceed();
+    long endTime = System.currentTimeMillis();
+    logger.info(joinPoint.getSignature() + " executed in " + (endTime - startTime) + "ms");
+    return proceed;
+  }
+}
+
+


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
The Pull Request:
- adds a util class to log the execution time for selected method with an Aspect decorator.
- replaces apt-get outdated instructions to avoid the warning:
`org.apache.tomcat.jni.LibraryNotFoundError: Can't load library: /Users/loubrieu/git/registry-api/service/bin/libtcnative-2.dylib, Can't load library: /Users/loubrieu/git/registry-api/service/bin/liblibtcnative-2.dylib, Can't load library: /Users/loubrieu/git/registry-api/service/bin/libtcnative-1.dylib, Can't load library: /Users/loubrieu/git/registry-api/service/bin/liblibtcnative-1.dylib, no tcnative-2 in java.library.path: /Users/loubrieu/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:., no libtcnative-2 in java.library.path: /Users/loubrieu/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:., no tcnative-1 in java.library.path: /Users/loubrieu/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:., no libtcnative-1 in java.library.path: /Users/loubrieu/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:`

The warning was likely to impact the performances of the spring-boot application.

Since it is assumed the time spent to improve performances can be infinite, I decide to stop here for now.


## ⚙️ Test Data and/or Report
Regressions tests have not been updated. We still have the 1s threshod for every requests.

No format tests have been done, but the monitoring of the method's execution duration did not reveal clearly if anything was lasting for too long, so the code is assumed to be good regarding the performances.

Then the missing tomcat library has been added since it is likely to improve the performances and did actually remove the warning. However to comparison tests have been done between the with or without. 

It has been noted that the first call to the API after  the service is restarted is longer than the following calls. So the tests should start after a first dummy call.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Fixes #623 


