### PR TITLE
update default registry index basename

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,18 @@ There are two approaches to running a local development instance of the API
 3. Temporarily disable certificate verification by making the following modification to [application.properties](./service/src/main/resources/application.properties)
 
        openSearch.sslCertificateCNVerification=false
+       
+4. If using the docker-compose setup (step 1), only one discipline node tenant is configured, it is 'geo', check this line:
 
-4. Build the application
+
+       openSearch.disciplineNodes=geo
+
+
+5. Build the application
 
        mvn clean install
 
-5. Start the application 
+6. Start the application 
 
        cd service
        mvn spring-boot:run
@@ -73,10 +79,10 @@ There are two approaches to running a local development instance of the API
 
 The API will now be accessible on (by default) https://localhost:8080
        
-6. Specific configuration profile: if you run the application in a specific environment you can define a dedicated `application.properties`, for example `application-dev.properties` that does not need to be commited on git. Launch it as follow:
+7. Specific configuration profile: if you run the application in a specific environment you can define a dedicated `application.properties`, for example `application-dev.properties` that does not need to be commited on git. Launch it as follow:
 
 
-    mvn -Dspring-boot.run.profiles=dev spring-boot:run
+       mvn -Dspring-boot.run.profiles=dev spring-boot:run
      
 
     

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -32,12 +32,12 @@ server.ssl.key-store-type=PKCS12
 
 # note the port is mandatory even when it is default :80 or :443
 openSearch.host=localhost:9200
-openSearch.registryIndex=geo-registry
-openSearch.registryRefIndex=geo-registry-refs
+openSearch.registryIndex=registry
+openSearch.registryRefIndex=registry-refs
 openSearch.timeOutSeconds=60
 # , separated list of the prefixes used in the opensearch indices, 
-# if none, keep this configuration empty.
-openSearch.disciplineNodes=
+# if none, keep this configuration empty. Default for test with docker-compose is 'geo' only.
+openSearch.disciplineNodes=geo
 openSearch.CCSEnabled=true
 openSearch.username=admin
 openSearch.password=admin

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -32,8 +32,8 @@ server.ssl.key-store-type=PKCS12
 
 # note the port is mandatory even when it is default :80 or :443
 openSearch.host=localhost:9200
-openSearch.registryIndex=registry
-openSearch.registryRefIndex=registry-refs
+openSearch.registryIndex=geo-registry
+openSearch.registryRefIndex=geo-registry-refs
 openSearch.timeOutSeconds=60
 # , separated list of the prefixes used in the opensearch indices, 
 # if none, keep this configuration empty.


### PR DESCRIPTION
 to reflect up-to-date dockerized registry configuration

## 🗒️ Summary
https://github.com/NASA-PDS/registry populates data under `geo-registry*` now rather than `registry*`, breaking compatibility with default `registry-api` configuration.

This updates the default-configured index names in application.properties to reflect this.

## ⚙️ Test Data and/or Report
Manually tested

## ♻️ Related Issues
n/a


