### PR TITLE
Support for the structured products in the registry

### DIFF
--- a/.github/workflows/branch-cicd.yaml
+++ b/.github/workflows/branch-cicd.yaml
@@ -97,7 +97,11 @@ jobs:
             -
                 name: ∫ Integration and deep archive tests … hold onto your hats, pardners
                 run: |
-                  .github/workflows/integration_tests.sh --verify
+                  if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+                    .github/workflows/integration_tests.sh
+                  else
+                    .github/workflows/integration_tests.sh --verify
+                  fi
 
 ...
 

--- a/.github/workflows/last_integration_test.json
+++ b/.github/workflows/last_integration_test.json
@@ -1,5 +1,5 @@
 {
-  "api_gitrev": "28a62abd285ff1c13fe83b06f974befe1a00c998",
+  "api_gitrev": "5e39a8604d4ffcf70b625186ae48321799ea16f3",
   "reg_gitrev": "0fcb3cfb684511ac071739f10aafcf07e6007379",
   "status": "success"
 }

--- a/.github/workflows/last_integration_test.json
+++ b/.github/workflows/last_integration_test.json
@@ -1,5 +1,5 @@
 {
-  "api_gitrev": "ddfb17cf345a6b2d92967dc6af9a103be251a359",
+  "api_gitrev": "a9e0779a96963687d3f1ab64385c9bb86dc0587d",
   "reg_gitrev": "0fcb3cfb684511ac071739f10aafcf07e6007379",
   "status": "success"
 }

--- a/.github/workflows/last_integration_test.json
+++ b/.github/workflows/last_integration_test.json
@@ -1,5 +1,5 @@
 {
-  "api_gitrev": "a9e0779a96963687d3f1ab64385c9bb86dc0587d",
+  "api_gitrev": "28a62abd285ff1c13fe83b06f974befe1a00c998",
   "reg_gitrev": "0fcb3cfb684511ac071739f10aafcf07e6007379",
   "status": "success"
 }

--- a/lexer/src/test/java/api/pds/nasa/gov/api_search_query_lexer/MockedListener.java
+++ b/lexer/src/test/java/api/pds/nasa/gov/api_search_query_lexer/MockedListener.java
@@ -168,10 +168,12 @@ public class MockedListener implements ParseTreeListener, SearchListener {
 
   @Override
   public void exitExistence(ExistenceContext ctx) {
+    // Nothing useful to do in this mocked version
   }
 
   @Override
   public void enterFields(FieldsContext ctx) {
+    // Nothing useful to do in this mocked version
   }
 
   @Override

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/SearchUtil.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/SearchUtil.java
@@ -22,7 +22,7 @@ public class SearchUtil {
 
   private static String fnArch;
   @Value("${registry.field.name.architecture}")
-  public void setFnArch(String fnArch) {
+  static public void setFnArch(String fnArch) {
     SearchUtil.fnArch = fnArch;
   }
 

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/SearchUtil.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/SearchUtil.java
@@ -8,17 +8,27 @@ import java.util.List;
 import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 import gov.nasa.pds.api.registry.exceptions.UnsupportedSearchProperty;
 import gov.nasa.pds.model.Metadata;
 import gov.nasa.pds.model.PdsProduct;
 import gov.nasa.pds.model.Reference;
 
+@Component
 public class SearchUtil {
 
   private static final Logger log = LoggerFactory.getLogger(SearchUtil.class);
 
+  private static String fnArch;
+  @Value("${registry.field.name.architecture}")
+  public void setFnArch(String fnArch) {
+    SearchUtil.fnArch = fnArch;
+  }
+
   static public String jsonPropertyToOpenProperty(String jsonProperty) {
-    return jsonProperty.replace(".", "/");
+    if ("flat".equalsIgnoreCase(SearchUtil.fnArch)) return jsonProperty.replace(".", "/");
+    return jsonProperty;
   }
 
   static public String[] jsonPropertyToOpenProperty(String[] jsonProperties) {
@@ -41,8 +51,8 @@ public class SearchUtil {
 
   static public String openPropertyToJsonProperty(String openProperty)
       throws UnsupportedSearchProperty {
-
-    return openProperty.replace('/', '.');
+    if ("flat".equalsIgnoreCase(SearchUtil.fnArch)) return openProperty.replace('/', '.');
+    return openProperty;
   }
 
   static private void addReference(ArrayList<Reference> to, String ID, URL baseURL) {

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/SearchUtil.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/SearchUtil.java
@@ -22,16 +22,16 @@ public class SearchUtil {
 
   private static String fnArch;
   @Value("${registry.field.name.architecture}")
-  static public void setFnArch(String fnArch) {
+  public static void setFnArch(String fnArch) {
     SearchUtil.fnArch = fnArch;
   }
 
-  static public String jsonPropertyToOpenProperty(String jsonProperty) {
+  public static String jsonPropertyToOpenProperty(String jsonProperty) {
     if (SearchUtil.fnArch == null || SearchUtil.fnArch.equalsIgnoreCase("flat")) return jsonProperty.replace(".", "/");
     return jsonProperty;
   }
 
-  static public String[] jsonPropertyToOpenProperty(String[] jsonProperties) {
+  public static String[] jsonPropertyToOpenProperty(String[] jsonProperties) {
     if (jsonProperties != null && jsonProperties.length > 0) {
       for (int i = 0; i < jsonProperties.length; i++) {
         jsonProperties[i] = jsonPropertyToOpenProperty(jsonProperties[i]);
@@ -40,7 +40,7 @@ public class SearchUtil {
     return jsonProperties;
   }
 
-  static public List<String> jsonPropertyToOpenProperty(List<String> jsonProperties) {
+  public static List<String> jsonPropertyToOpenProperty(List<String> jsonProperties) {
     if (jsonProperties != null && jsonProperties.size() > 0) {
       for (int i = 0; i < jsonProperties.size(); i++) {
         jsonProperties.set(i, jsonPropertyToOpenProperty(jsonProperties.get(i)));
@@ -49,13 +49,13 @@ public class SearchUtil {
     return jsonProperties;
   }
 
-  static public String openPropertyToJsonProperty(String openProperty)
+  public static String openPropertyToJsonProperty(String openProperty)
       throws UnsupportedSearchProperty {
     if (SearchUtil.fnArch == null || SearchUtil.fnArch.equalsIgnoreCase("flat")) return openProperty.replace('/', '.');
     return openProperty;
   }
 
-  static private void addReference(ArrayList<Reference> to, String ID, URL baseURL) {
+  private static void addReference(ArrayList<Reference> to, String ID, URL baseURL) {
     Reference reference = new Reference();
     reference.setId(ID);
 
@@ -86,7 +86,7 @@ public class SearchUtil {
     to.add(reference);
   }
 
-  static private PdsProduct addPropertiesFromESEntity(PdsProduct product, EntityProduct ep,
+  private static PdsProduct addPropertiesFromESEntity(PdsProduct product, EntityProduct ep,
       URL baseURL) {
     product.setId(ep.getLidVid());
     product.setType(ep.getProductClass());
@@ -155,7 +155,7 @@ public class SearchUtil {
     return product;
   }
 
-  static public PdsProduct entityProductToAPIProduct(EntityProduct ep, URL baseURL) {
+  public static PdsProduct entityProductToAPIProduct(EntityProduct ep, URL baseURL) {
     log.debug("convert EntityProduct (ep) to API object without XML label");
 
     PdsProduct product = new PdsProduct();

--- a/service/src/main/java/gov/nasa/pds/api/registry/model/SearchUtil.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/model/SearchUtil.java
@@ -27,7 +27,7 @@ public class SearchUtil {
   }
 
   static public String jsonPropertyToOpenProperty(String jsonProperty) {
-    if ("flat".equalsIgnoreCase(SearchUtil.fnArch)) return jsonProperty.replace(".", "/");
+    if (SearchUtil.fnArch == null || SearchUtil.fnArch.equalsIgnoreCase("flat")) return jsonProperty.replace(".", "/");
     return jsonProperty;
   }
 
@@ -51,7 +51,7 @@ public class SearchUtil {
 
   static public String openPropertyToJsonProperty(String openProperty)
       throws UnsupportedSearchProperty {
-    if ("flat".equalsIgnoreCase(SearchUtil.fnArch)) return openProperty.replace('/', '.');
+    if (SearchUtil.fnArch == null || SearchUtil.fnArch.equalsIgnoreCase("flat")) return openProperty.replace('/', '.');
     return openProperty;
   }
 

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -51,3 +51,7 @@ filter.archiveStatus=archived,certified
 # source version from maven
 # need to be updated with actual value when runs outside of maven
 registry.service.version=@project.version@
+
+# signal if the database being used is "flat" or "structured"
+# used an enum of strings, "flat" or "structured" for future new types
+registry.field.name.architecture=structured

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -86,11 +86,7 @@ resource "aws_ecs_cluster" "pds-registry-api-ecs" {
   }
 }
 
-# Do we need individual dev/test/prod repositories?
-# I don't think we do, but then we need to use prod account instead of the dev account, would that work ?
-data "aws_ecr_repository" "pds-registry-api-service" {
-  name = "pds-registry-api-service"
-}
+# ECR repository is now defined in ecr.tf
 
 # Log groups hold logs from our app.
 resource "aws_cloudwatch_log_group" "pds-registry-log-group" {
@@ -112,7 +108,7 @@ resource "aws_ecs_task_definition" "pds-registry-ecs-task" {
   [
     {
       "name": "pds-${var.venue}-reg-container",
-      "image": "${var.aws_fg_image}",
+      "image": "${aws_ecr_repository.pds-registry-api-service.repository_url}:latest",
       "portMappings": [
         {
           "containerPort": 80

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -49,10 +49,6 @@ variable "ecs_task_execution_role" {
   description = "ECS task execution role"
 }
 
-variable "aws_fg_image" {
-  description = "AWS image name for Fargate"
-}
-
 variable "aws_s3_bucket_logs_id" {
   description = "AWS S3 bucket with the logs"
 }


### PR DESCRIPTION
## 🗒️ Summary
In order for the registry-api to use the structured field names, need to quit doing the property name conversions. Made it selectable via the properties file just because the transition from one to the other may take a while. This gives us the freedom to use the same API code for older or newer registry-apis.


## ⚙️ Test Data and/or Report
All postman tests pass.

## ♻️ Related Issues
Last step. Closes #632 

## 🤓 Reviewer Checklist

*Reviewers: Please verify the following before approving this pull request.*

### Security & Quality
- [ ] **SonarCloud:** Confirmed no new High or Critical security findings.
- [ ] **Secrets Detection:** Verified that the Secrets Detection scan passed and no sensitive information (keys, tokens, PII) is exposed.
- [ ] **Code Quality:** Code follows organization style guidelines and best practices for the specific language (e.g., PEP 8, Google Java Style).

### Testing & Validation
- [ ] **Test Accuracy:** Verified that test data is accurate, representative of real-world PDS4 scenarios, and sufficient for the logic being tested.
- [ ] **Coverage:** Automated tests cover new logic and edge cases.
- [ ] **Local Verification:** (If applicable) Successfully built and ran the changes in a local or staging environment.

### Documentation
- [ ] **Documentation:** README, Wiki, or inline documentation (Sphinx, Javadoc, Docstrings) have been updated to reflect these changes.

### Maintenance
- [ ] **Issue Traceability:** The PR is linked to a valid GitHub Issue or Jira Ticket.
- [ ] **Backward Compatibility:** Confirmed that these changes do not break existing downstream dependencies or API contracts (or that breaking changes are clearly documented).
