### PR TITLE
Back merge fixes for release candidate/1.7.0

### DIFF
--- a/.github/workflows/integration_tests.sh
+++ b/.github/workflows/integration_tests.sh
@@ -64,8 +64,8 @@ run() {
     cd docker || exit 1
     ddir=$(pwd)
     ( cd certs || exit 1 ; ./generate-certs.sh )
-    export REG_API_IMAGE=nasapds/registry-api-service:latest
-    docker image inspect nasapds/registry-api-service:latest >/dev/null
+    export REG_API_IMAGE=nasapds/registry-api-service:${registry_api_tag:-latest}
+    docker image inspect "nasapds/registry-api-service:${registry_api_tag:-latest}" >/dev/null
     echo "launch services"
     docker compose \
            --ansi never \
@@ -110,15 +110,35 @@ run() {
     return $status
 }
 
+registry_api_tag=""
+registry_branch=""
 verbose=false
 verify=false
 for arg in "$@"; do
     case "$arg" in
         --verbose) verbose=true ;;
         --verify)  verify=true ;;
+        --registry-branch=*)   registry_branch="${arg#--registry-branch=}" ;;
+        --registry-api-tag=*)  registry_api_tag="${arg#--registry-api-tag=}" ;;
         *)
             echo "Error: Invalid argument '$arg'"
-            echo "Usage: $0 [--verify] [--verbose]"
+            echo "Usage: $0 [--verify] [--verbose] [--registry-branch=<branch>] [--registry-api-tag=<tag>]"
+            echo
+            echo "Options:"
+            echo "  --verify                       Verify that the last integration test result is"
+            echo "                                 still valid for the current commit (no re-run)."
+            echo "  --verbose                      Print docker compose logs after the test run."
+            echo "  --registry-branch=<branch>     Check out the given branch of NASA-PDS/registry"
+            echo "                                 for the integration tests instead of the default"
+            echo "                                 behaviour, which auto-selects a branch whose name"
+            echo "                                 matches the current registry-api branch (falling"
+            echo "                                 back to the registry default branch when no match"
+            echo "                                 is found)."
+            echo "  --registry-api-tag=<tag>       Use the given Docker Hub tag for the registry-api"
+            echo "                                 service image (nasapds/registry-api-service:<tag>)"
+            echo "                                 instead of building the image from the current"
+            echo "                                 source. When this option is set the Maven build and"
+            echo "                                 docker build steps are skipped."
             exit 1 ;;
     esac
 done
@@ -136,10 +156,16 @@ echo "temporary directory: $tdir"
 trap 'rm -rf "$tdir"' EXIT
 export tdir
 cd "$tdir" || exit 1
+echo "Cloning NASA-PDS/registry repository into temporary directory: $tdir"
 git clone --quiet https://github.com/NASA-PDS/registry.git
 cd registry || exit 1
-if git show-ref --verify --quiet refs/remotes/origin/"$branchname"
+if [ -n "$registry_branch" ]
 then
+    echo "Switching to requested registry branch: $registry_branch"
+    git switch "$registry_branch"
+elif git show-ref --verify --quiet refs/remotes/origin/"$branchname"
+then
+    echo "Switching to matching registry branch: $branchname"
     git switch "$branchname"
 fi
 echo "registry being used"
@@ -214,7 +240,7 @@ if $verify; then
 else
     cd "$rdir" || exit 1
     clean || exit 2
-    build || exit 3
+    [ -z "$registry_api_tag" ] && { build || exit 3; }
     cd "$tdir"/registry || exit 1
     ( set -o pipefail ; run 2>&1 | tee "$rdir"/integration_tests.rpt.txt ) \
         && status=success || status=failure

--- a/.github/workflows/last_integration_test.json
+++ b/.github/workflows/last_integration_test.json
@@ -1,5 +1,5 @@
 {
-  "api_gitrev": "df3a8b95d99afff894713f4f5cd7c7b2381321ab+",
+  "api_gitrev": "a550f43949944ed5446f15e9bc49a1d667994509+",
   "reg_gitrev": "bd844d424da08fc692ee5b6e9dc7b2ed91a3e2b9",
   "status": "success"
 }

--- a/.github/workflows/last_integration_test.json
+++ b/.github/workflows/last_integration_test.json
@@ -1,5 +1,5 @@
 {
-  "api_gitrev": "b0711d49e711ff012dca26ff455682b29a5ca99c+",
-  "reg_gitrev": "dda5e706096b4e50575006f85f82f3c111d05b1f",
+  "api_gitrev": "df3a8b95d99afff894713f4f5cd7c7b2381321ab+",
+  "reg_gitrev": "bd844d424da08fc692ee5b6e9dc7b2ed91a3e2b9",
   "status": "success"
 }

--- a/service/src/main/java/gov/nasa/pds/api/registry/controllers/SecurityValidationFilter.java
+++ b/service/src/main/java/gov/nasa/pds/api/registry/controllers/SecurityValidationFilter.java
@@ -82,6 +82,8 @@ public class SecurityValidationFilter implements HandlerInterceptor {
       String serverName = request.getServerName();
       log.debug("Servername is {}", serverName);
       if (!authorizedServerName(serverName)) {
+        log.error("Server cannot be proxied from {} but from {}", serverName,
+                this.authorizedForwardedHosts);
         throw new UnauthorizedForwardedHostException("Server cannot be proxied from " + serverName);
       }
     }


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
<!--
   Brief summary of changes if not sufficiently described by commit messages.
-->

Back merge changes made while preparing for the release 1.7.0 deployment in production with terraform.
Introduced more flexibility in the integration testing to use different registry branches and local registry-api docker tags.

### 🤖 AI Assistance Disclosure
- [ ] No AI assistance used
- [ ] AI used for light assistance (e.g., suggestions, refactoring, documentation help, minor edits)
- [ ] AI used for moderate content generation (AI generated some code or logic, but the developer authored or heavily revised the majority)
- [x] AI generated substantial portions of this code

Estimated % of code influenced by AI: _90_ %

## ⚙️ Test Data and/or Report
<!--
   You MUST include one of:
   1. If automated tests, refer to where tests are documented and/or link to separate PR.
   2. If manual tests, show procedure and/or output
   3. If not tested, describe rationale for not including.
-->

Tested with the integration tests automated on the branch as well as terraform deployment with integration tests in the AWS Test venue.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Fixes https://github.com/NASA-PDS/registry/issues/542

## 🤓 Reviewer Checklist

*Reviewers: Please verify the following before approving this pull request.*

### Documentation and PR Content
- [ ] **Documentation:** README, Wiki, or inline documentation (Sphinx, Javadoc, Docstrings) have been updated to reflect these changes.
- [ ] **Issue Traceability:** The PR is linked to a valid GitHub Issue
- [ ] **PR Title:** The PR title is "user-friendly" clearly identifying what is being fixed or the new feature being added, that if you saw it in the Release Notes for a tool, you would be able to get the gist of what was done.

### Security & Quality
- [ ] **SonarCloud:** Confirmed no new High or Critical security findings.
- [ ] **Secrets Detection:** Verified that the Secrets Detection scan passed and no sensitive information (keys, tokens, PII) is exposed.
- [ ] **Code Quality:** Code follows organization style guidelines and best practices for the specific language (e.g., PEP 8, Google Java Style).

### Testing & Validation
- [ ] **Test Accuracy:** Verified that test data is accurate, representative of real-world PDS4 scenarios, and sufficient for the logic being tested.
- [ ] **Coverage:** Automated tests cover new logic and edge cases.
- [ ] **Local Verification:** (If applicable) Successfully built and ran the changes in a local or staging environment.

### Maintenance
- [ ] **Backward Compatibility:** Confirmed that these changes do not break existing downstream dependencies or API contracts (or that breaking changes are clearly documented).

### Terraform (only if this PR touches a `terraform/` directory)
<!--
    `scripts/validate_terraform.py` (see NASA-PDS/pds-terraform-conventions) mechanically
    checks most of the org's Must-Have Terraform requirements, but it cannot verify the
    items below — they require a human reviewer's judgment. Check the validator's own
    output too: it lists these same items as "not statically checked" rather than passing
    them by default.
-->
- [ ] **Validator run:** `scripts/validate_terraform.py` was run against the changed `terraform/` tree and any Must-Have failures were resolved (or are tracked in a reviewed `.tfvalidate-ignore` entry, not silently bypassed).
- [ ] **Ownership boundary:** Shared/singleton CDS resources (Cognito, CloudFront, org-wide IAM roles, shared security groups) were only added/changed in `pdc-cds-infra`, not duplicated in an application repo.
- [ ] **Module structure:** `modules/` stays flat and no new module is just a thin wrapper around a single resource.
- [ ] **SSM interface:** Any new cross-component output is actually published under `/pds/<component>/...` and, if this PR is the consumer side, reads from the correct published parameter rather than another repo's Terraform state.
- [ ] **Naming intent:** Resource and variable names are semantically meaningful, not just non-redundant (the validator only checks for repeated resource-type substrings).
- [ ] **Auth at runtime:** Terraform/CI actually authenticates via OIDC or an assumed role when applied — not just "no static key found in this diff."
- [ ] **Least privilege:** Any new or changed IAM policy attached to the Terraform execution role grants only what this change needs.
